### PR TITLE
Error on Windows Mobile with french keyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,3 @@ QA/*
 QSF/*
 SampleApps/*
 *VSIX*
-/Controls/App3

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ QA/*
 QSF/*
 SampleApps/*
 *VSIX*
+/Controls/App3

--- a/Controls/Core.UWP/Common/DeviceType.cs
+++ b/Controls/Core.UWP/Common/DeviceType.cs
@@ -1,0 +1,74 @@
+﻿using Windows.System.Profile;
+using Windows.UI.ViewManagement;
+
+// ReSharper disable once CheckNamespace
+namespace Telerik.Core
+{
+    /// <summary>
+    /// Helper class to get device type
+    /// </summary>
+    public static class DeviceTypeHelper
+    {
+        /// <summary>
+        /// Get the device type (XBox, Continuum, Tablet, Desktop, Iot...)
+        /// </summary>
+        /// <returns></returns>
+        public static DeviceType GetDeviceType()
+        {
+            switch (AnalyticsInfo.VersionInfo.DeviceFamily)
+            {
+                case "Windows.Mobile":
+                    return UIViewSettings.GetForCurrentView().UserInteractionMode == UserInteractionMode.Mouse ? DeviceType.Continuum : DeviceType.Phone;
+                case "Windows.Xbox":
+                    return DeviceType.Xbox;
+                case "Windows.Desktop":
+                    return UIViewSettings.GetForCurrentView().UserInteractionMode == UserInteractionMode.Mouse ? DeviceType.Desktop : DeviceType.Tablet;
+                case "Windows.Universal":
+                    return DeviceType.IoT;
+                case "Windows.Team":
+                    return DeviceType.SurfaceHub;
+                default:
+                    return DeviceType.Other;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Device type
+    /// </summary>
+    public enum DeviceType
+    {
+        /// <summary>
+        /// Phone
+        /// </summary>
+        Phone,
+        /// <summary>
+        /// Desktop
+        /// </summary>
+        Desktop,
+        /// <summary>
+        /// Tablet
+        /// </summary>
+        Tablet,
+        /// <summary>
+        /// IOT
+        /// </summary>
+        IoT,
+        /// <summary>
+        /// Xbox
+        /// </summary>
+        Xbox,
+        /// <summary>
+        /// SurfaceHub
+        /// </summary>
+        SurfaceHub,
+        /// <summary>
+        /// Continuum
+        /// </summary>
+        Continuum,
+        /// <summary>
+        /// Other
+        /// </summary>
+        Other
+    }
+}

--- a/Controls/Core.UWP/Core.UWP.csproj
+++ b/Controls/Core.UWP/Core.UWP.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Common\BaseCommand.cs" />
     <Compile Include="Common\BitStateChangedEventArgs.cs" />
     <Compile Include="Common\BitVector32.cs" />
+    <Compile Include="Common\DeviceType.cs" />
     <Compile Include="Common\DisposableObject.cs" />
     <Compile Include="Common\ElementTreeHelper.cs" />
     <Compile Include="Common\ExportHelper.cs" />

--- a/Controls/Input/Input.UWP/NumericBox/RadNumericBox.cs
+++ b/Controls/Input/Input.UWP/NumericBox/RadNumericBox.cs
@@ -8,6 +8,7 @@ using Windows.System;
 using Windows.System.Profile;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 
 namespace Telerik.UI.Xaml.Controls.Input
@@ -890,7 +891,6 @@ namespace Telerik.UI.Xaml.Controls.Input
             {
                 return this.currentCulture.NumberFormat.NumberDecimalSeparator == ",";
             }
-
             return false;
         }
 
@@ -929,6 +929,8 @@ namespace Telerik.UI.Xaml.Controls.Input
         {
             this.UpdateVisualState(true);
             this.ValidateText();
+            if (this.GetBindingExpression(ValueProperty)?.ParentBinding.UpdateSourceTrigger == UpdateSourceTrigger.PropertyChanged && !String.IsNullOrWhiteSpace(this.TextBox.Text))
+                this.Value = this.TryParseValue();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "Telerik.UI.Xaml.Controls.Input.RadNumericBox.SetText(System.String)")]

--- a/Controls/Input/Input.UWP/NumericBox/RadNumericBox.cs
+++ b/Controls/Input/Input.UWP/NumericBox/RadNumericBox.cs
@@ -121,7 +121,7 @@ namespace Telerik.UI.Xaml.Controls.Input
         private bool updatingValue;
         private bool allowNullValueCache;
         private double? valueCache;
-        private bool _internalChange;
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="RadNumericBox" /> class.
         /// </summary>
@@ -837,8 +837,11 @@ namespace Telerik.UI.Xaml.Controls.Input
 
             if (oldValue != numericBox.Value)
             {
-                if (!numericBox._internalChange)
+                if (numericBox.TextBox != null && numericBox.TextBox.FocusState == FocusState.Unfocused)
+                {
                     numericBox.UpdateTextBoxText();
+                }
+                
                 numericBox.OnValueChanged();
             }
         }
@@ -931,9 +934,7 @@ namespace Telerik.UI.Xaml.Controls.Input
             this.ValidateText();
             if (this.GetBindingExpression(ValueProperty)?.ParentBinding.UpdateSourceTrigger == UpdateSourceTrigger.PropertyChanged)
             {
-                this._internalChange = true;
                 this.Value = this.TryParseValue();
-                this._internalChange = false;
             }
         }
 

--- a/Controls/Input/Input.UWP/NumericBox/RadNumericBox.cs
+++ b/Controls/Input/Input.UWP/NumericBox/RadNumericBox.cs
@@ -5,6 +5,7 @@ using Telerik.Core;
 using Telerik.UI.Xaml.Controls.Input.NumericBox;
 using Telerik.UI.Xaml.Controls.Primitives;
 using Windows.System;
+using Windows.System.Profile;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
@@ -137,7 +138,7 @@ namespace Telerik.UI.Xaml.Controls.Input
         /// Occurs when the current value has changed.
         /// </summary>
         public event EventHandler ValueChanged;
-        
+
         /// <summary>
         /// Gets or sets the context for input used by this RadNumericBox.
         /// </summary>
@@ -766,7 +767,7 @@ namespace Telerik.UI.Xaml.Controls.Input
 
         private static bool IsNumericKey(VirtualKey key)
         {
-            if (RadNumericBox.IsAzertyKeyboard && key == VirtualKey.Number6)
+            if (RadNumericBox.IsAzertyKeyboard && key == VirtualKey.Number6 && AnalyticsInfo.VersionInfo.DeviceFamily != "Windows.Mobile")
             {
                 return false;
             }
@@ -790,7 +791,7 @@ namespace Telerik.UI.Xaml.Controls.Input
 
             if (RadNumericBox.IsAzertyKeyboard)
             {
-                isNegativeSign = isNegativeSign || key == VirtualKey.Number6;
+                isNegativeSign = isNegativeSign || (key == VirtualKey.Number6 && AnalyticsInfo.VersionInfo.DeviceFamily != "Windows.Mobile");
             }
 
             return isNegativeSign;


### PR DESCRIPTION
Hello,

With the open sourcing of Telerik UI for UWP, I finally found the problem for my thicket no 1066182

With a french keyboard on Windows Mobile, when you press the key 6, it add the sign - on the numeric box instead of adding the key 6.

I just add a chek if the device is a mobile.

Please update nuget package so I can use the control :-)