### PR TITLE
RadBulletGraph measures out of range in some scenarios

### DIFF
--- a/Controls/DataVisualization/DataVisualization.UWP/Bulletgraph/RadBulletGraph.cs
+++ b/Controls/DataVisualization/DataVisualization.UWP/Bulletgraph/RadBulletGraph.cs
@@ -613,9 +613,9 @@ namespace Telerik.UI.Xaml.Controls.DataVisualization
 
                     this.SetValuesInRange(FeaturedMeasureStartValueProperty, startValue, endValue);
                     this.SetValuesInRange(ComparativeMeasureProperty, startValue, endValue);
-                    this.SetValuesInRange(ProjectedMeasureProperty, this.FeaturedMeasureStartValue, endValue);
-                    this.SetValuesInRange(FeaturedMeasureProperty, this.FeaturedMeasureStartValue, endValue);
-                    this.SetValuesInRange(FeaturedMeasureStartValueProperty, startValue, this.FeaturedMeasure);
+                    this.SetValuesInRange(ProjectedMeasureProperty, startValue, endValue);
+                    this.SetValuesInRange(FeaturedMeasureProperty, startValue, endValue);
+                    this.SetValuesInRange(FeaturedMeasureStartValueProperty, startValue, endValue);
 
                     this.isValueCoerceScheduled = false;
                 });


### PR DESCRIPTION
Using local StartValue/EndValue values to consistently put all BulletGraph measures in this range. Previously they could become inconsistent due to async call, e.g. when another property is changed right away, animation, etc.