### PR TITLE
Improve RadRating accessibility for Narrator and keyboard support

### DIFF
--- a/Controls/Input/Input.UWP/Rating/AutomationPeers/RadRatingAutomationPeer.cs
+++ b/Controls/Input/Input.UWP/Rating/AutomationPeers/RadRatingAutomationPeer.cs
@@ -4,13 +4,14 @@ using Telerik.UI.Xaml.Controls.Input;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Automation.Provider;
 using System.Linq;
+using Windows.UI.Xaml.Automation;
 
 namespace Telerik.UI.Automation.Peers
 {
     /// <summary>
     /// Automation peer class for RadRating.
     /// </summary>
-    public class RadRatingAutomationPeer : RadControlAutomationPeer, IValueProvider, ISelectionProvider
+    public class RadRatingAutomationPeer : RadControlAutomationPeer, IValueProvider, IRangeValueProvider
     {
         private RadRating Rating
         {
@@ -47,7 +48,15 @@ namespace Telerik.UI.Automation.Peers
         {
             get
             {
-                return this.Rating.Value.ToString();
+                var localizedRatingString = InputLocalizationManager.Instance.GetString("RatingValueString");
+                if (!string.IsNullOrEmpty(localizedRatingString))
+                {
+                    return string.Format(localizedRatingString, this.Rating.Value, this.Maximum);
+                }
+                else
+                {
+                    return "Rating unset";
+                }
             }
         }
 
@@ -66,47 +75,12 @@ namespace Telerik.UI.Automation.Peers
             {
                 throw new InvalidOperationException("Given string is not successfully parsed to double");
             }
-        }
-
-        // <summary>
-        // Retrieves a UI Automation provider for each child element that is selected.
-        // </summary>
-        public IRawElementProviderSimple[] GetSelection()
-        {
-            RadRatingItem selectedRatingItem = this.Rating.Items.LastOrDefault(item => this.Rating.GetIndexOf(item) < this.Rating.Value);
-            if (selectedRatingItem != null)
-            {
-                return new[] { ProviderFromPeer(FromElement(selectedRatingItem)) };
-            }
-            return new IRawElementProviderSimple[] { };
-        }
-
-        /// <summary>
-        ///  Gets a value that specifies whether the UI Automation provider allows more than one child element to be selected concurrently.
-        /// </summary>
-        public bool CanSelectMultiple
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Gets a value that specifies whether the UI Automation provider requires at least one child element to be selected.
-        /// </summary>
-        public bool IsSelectionRequired
-        {
-            get
-            {
-                return false;
-            }
-        }        
+        }       
 
         /// <inheritdoc />	
         protected override object GetPatternCore(PatternInterface patternInterface)
         {
-            if (patternInterface == PatternInterface.Value || patternInterface == PatternInterface.Selection)
+            if (patternInterface == PatternInterface.Value || patternInterface == PatternInterface.RangeValue)
             {
                 return this;
             }
@@ -116,7 +90,7 @@ namespace Telerik.UI.Automation.Peers
         /// <inheritdoc />	
         protected override AutomationControlType GetAutomationControlTypeCore()
         {
-            return AutomationControlType.Slider | AutomationControlType.List;
+            return AutomationControlType.Slider;
         }
 
         /// <inheritdoc />
@@ -129,13 +103,42 @@ namespace Telerik.UI.Automation.Peers
             if (this.Rating != null && !string.IsNullOrEmpty(this.Rating.Name))
                 return this.Rating.Name;
 
-            return string.Empty;
+            return "Ratings control";
         }
 
         /// <inheritdoc />
         protected override string GetLocalizedControlTypeCore()
         {
-            return "rad rating";
-        }          
+            return "slider";
+        }
+
+        /// <inheritdoc />
+        public void SetValue(double value)
+        {
+            RadRating owner = base.Owner as RadRating;
+            owner.Value = value;
+        }
+
+        /// <inheritdoc />
+        public double LargeChange => 1.0;
+
+        /// <inheritdoc />
+        public double Maximum => 5.0;
+
+        /// <inheritdoc />
+        public double Minimum => 0.0;
+
+        /// <inheritdoc />
+        public double SmallChange => 1.0;
+
+        /// <inheritdoc />
+        double IRangeValueProvider.Value
+        {
+            get
+            {
+                RadRating owner = base.Owner as RadRating;
+                return owner.Value;
+            }
+        }
     }
 }

--- a/Controls/Input/Input.UWP/Rating/AutomationPeers/RadRatingAutomationPeer.cs
+++ b/Controls/Input/Input.UWP/Rating/AutomationPeers/RadRatingAutomationPeer.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using Telerik.UI.Automation.Peers;
 using Telerik.UI.Xaml.Controls.Input;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Automation.Provider;
-using System.Linq;
-using Windows.UI.Xaml.Automation;
 
 namespace Telerik.UI.Automation.Peers
 {
@@ -53,10 +50,8 @@ namespace Telerik.UI.Automation.Peers
                 {
                     return string.Format(localizedRatingString, this.Rating.Value, this.Maximum);
                 }
-                else
-                {
-                    return "Rating unset";
-                }
+
+                return "Rating unset";
             }
         }
 
@@ -84,6 +79,7 @@ namespace Telerik.UI.Automation.Peers
             {
                 return this;
             }
+
             return base.GetPatternCore(patternInterface);
         }
 
@@ -123,7 +119,7 @@ namespace Telerik.UI.Automation.Peers
         public double LargeChange => 1.0;
 
         /// <inheritdoc />
-        public double Maximum => 5.0;
+        public double Maximum => this.Rating.Items.Count;
 
         /// <inheritdoc />
         public double Minimum => 0.0;
@@ -136,8 +132,7 @@ namespace Telerik.UI.Automation.Peers
         {
             get
             {
-                RadRating owner = base.Owner as RadRating;
-                return owner.Value;
+                return this.Rating.Value;
             }
         }
     }

--- a/Controls/Input/Input.UWP/Rating/RadRating.cs
+++ b/Controls/Input/Input.UWP/Rating/RadRating.cs
@@ -557,49 +557,33 @@ namespace Telerik.UI.Xaml.Controls.Input
         /// <inheritdoc/>
         protected override void OnKeyDown(KeyRoutedEventArgs e)
         {
-            if (e.Handled) return;
-
-            if (!IsReadOnly)
+            if (e.Handled)
             {
-                // mark it not handled yet
+                return;
+            }
+
+            if (!this.IsReadOnly)
+            {
                 bool handled = false;
 
-                // get the virtual key
-                VirtualKey key = e.Key;
-                VirtualKey originalKey = e.OriginalKey;
-
-                // map up/down on keyboard to right/left for increment/decrement
-                if (originalKey == VirtualKey.Up)
-                {
-                    key = VirtualKey.Right;
-                }
-                else if (originalKey == VirtualKey.Down)
-                {
-                    key = VirtualKey.Left;
-                }
-
-                switch (key)
+                switch (e.Key)
                 {
                     case VirtualKey.Left:
-                        // decrement the rating
-                        Value--;
+                    case VirtualKey.Down:
+                        this.Value--;
                         handled = true;
                         break;
                     case VirtualKey.Right:
-                        // increment the rating
-                        Value++;
+                    case VirtualKey.Up:
+                        this.Value++;
                         break;
                     case VirtualKey.Home:
-                        // set rating to 0
-                        Value = 0.0;
+                        this.Value = 0.0;
                         handled = true;
                         break;
                     case VirtualKey.End:
-                        // set rating to max
-                        Value = 5.0;
+                        this.Value = this.Items.Count;
                         handled = true;
-                        break;
-                    default:
                         break;
                 }
 

--- a/Controls/Input/Input.UWP/Rating/RadRatingItem.cs
+++ b/Controls/Input/Input.UWP/Rating/RadRatingItem.cs
@@ -189,12 +189,6 @@ namespace Telerik.UI.Xaml.Controls.Input
                 case Windows.System.VirtualKey.Space:
                     this.Select();
                     break;
-                case Windows.System.VirtualKey.Right:
-                    FocusManager.TryMoveFocus(FocusNavigationDirection.Next);
-                    break;
-                case Windows.System.VirtualKey.Left:
-                    FocusManager.TryMoveFocus(FocusNavigationDirection.Previous);
-                    break;
             }            
         }
 

--- a/Controls/Input/Input.UWP/Resources/Neutral.resw
+++ b/Controls/Input/Input.UWP/Resources/Neutral.resw
@@ -171,6 +171,9 @@
   <data name="PosterizeToolText" xml:space="preserve">
     <value>Posterize</value>
   </data>
+  <data name="RatingValueString" xml:space="preserve">
+    <value>Rating, {0} of {1}</value>
+  </data>
   <data name="RotateToolText" xml:space="preserve">
     <value />
   </data>

--- a/Controls/Input/Input.UWP/Themes/Generic.xaml
+++ b/Controls/Input/Input.UWP/Themes/Generic.xaml
@@ -322,7 +322,6 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="AutomationProperties.Name" Value="Ratings control" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:RadRating">

--- a/Controls/Input/Input.UWP/Themes/Generic.xaml
+++ b/Controls/Input/Input.UWP/Themes/Generic.xaml
@@ -322,6 +322,7 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="AutomationProperties.Name" Value="Ratings control" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:RadRating">


### PR DESCRIPTION
This PR adds some improved keyboarding for RadRating enabling left/right/up/down/home/end arrow support for setting the value.  Additionally it implements the Range pattern for accessible technologies (e.g., Narrator) to be able to more properly interact with these screen readers to provide more valuable information and announce when the value changes as a result of input.
