### PR TITLE
Fix DataGridComboBoxColumn bugs

### DIFF
--- a/Controls/Data.UWP/Data/Engine/Helpers/BindingExpressionHelper.cs
+++ b/Controls/Data.UWP/Data/Engine/Helpers/BindingExpressionHelper.cs
@@ -13,39 +13,8 @@ namespace Telerik.Data.Core
         /// <param name="propertyPath">The path of the property which value will be returned.</param>
         public static Func<object, object> CreateGetValueFunc(Type itemType, string propertyPath)
         {
-#if WINDOWS_UWP
             PropertyInfo propertyInfo = itemType.GetRuntimeProperty(propertyPath);
-            return item => propertyInfo.GetValue(item);
-#else  
-            var parameter = Expression.Parameter(itemType, "item");
-
-            Expression get;
-            if (string.IsNullOrEmpty(propertyPath))
-            {
-                get = parameter;
-            }
-            else
-            {
-                try
-                {
-                    get = Expression.PropertyOrField(parameter, propertyPath);
-                }
-                catch (ArgumentException)
-                {
-                    return p => null;
-                }
-            }
-
-            var lambda = Expression.Lambda(get, parameter);
-
-            var compiled = lambda.Compile();
-
-            var methodInfo = typeof(BindingExpressionHelper).GetTypeInfo()
-                 .GetDeclaredMethod("ToUntypedFunc")
-                 .MakeGenericMethod(new[] { itemType, lambda.Body.Type });
-
-            return (Func<object, object>)methodInfo.Invoke(null, new object[] { compiled });
-#endif
+            return item => propertyInfo?.GetValue(item);
         }
 
         internal static Action<object, object> CreateSetValueAction(Type itemType, string propertyPath)

--- a/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridComboBoxColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridComboBoxColumn.cs
@@ -147,7 +147,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
         {
             var item = this.GetValueForInstance(instance);
 
-            if (string.IsNullOrEmpty(this.SelectedValuePath))
+            if (string.IsNullOrEmpty(this.SelectedValuePath) && !string.IsNullOrEmpty(this.DisplayMemberPath))
             {
                 var type = item.GetType();
                 if (this.itemPropertyGetter == null)
@@ -172,7 +172,10 @@ namespace Telerik.UI.Xaml.Controls.Grid
         /// <inheritdoc/>
         internal override FrameworkElement CreateEditorContentVisual()
         {
-            return new ComboBox();
+            var comboBoxEditor = new ComboBox();
+            comboBoxEditor.Unloaded += this.OnComboBoxUnloaded;
+            comboBoxEditor.SelectionChanged += this.OnComboBoxSelectionChanged;
+            return comboBoxEditor;
         }
 
         /// <inheritdoc/>
@@ -217,9 +220,11 @@ namespace Telerik.UI.Xaml.Controls.Grid
                     var comboBoxValueGetter = BindingExpressionHelper.CreateGetValueFunc(source.First().GetType(), this.SelectedValuePath);
                     var selectedItem = source.FirstOrDefault(x =>
                     {
-                        return comboBoxValueGetter(x).Equals(this.GetValueForInstance(item));
-                    });
+                        var selectedItemValue = comboBoxValueGetter(x)?.Equals(this.GetValueForInstance(item));
 
+                        return selectedItemValue.HasValue ? selectedItemValue.Value : false;
+                    });
+                    
                     (editorContent as ComboBox).SelectedItem = selectedItem;
                     editorContent.SetBinding(ComboBox.SelectedValueProperty, binding);
                 }
@@ -316,6 +321,26 @@ namespace Telerik.UI.Xaml.Controls.Grid
             {
                 column.itemPropertyGetter = BindingExpressionHelper.CreateGetValueFunc(column.itemsType, (string)e.NewValue);
                 column.OnProperyChange(UpdateFlags.All);
+            }
+        }
+
+        private void OnComboBoxUnloaded(object sender, RoutedEventArgs e)
+        {
+            var comboBox = sender as ComboBox;
+            if (comboBox != null)
+            {
+                comboBox.Unloaded -= this.OnComboBoxUnloaded;
+                comboBox.SelectionChanged -= this.OnComboBoxSelectionChanged;
+            }
+        }
+
+        private void OnComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var comboBox = sender as ComboBox;
+            if (comboBox != null)
+            {
+                comboBox.InvalidateMeasure();
+                comboBox.InvalidateArrange();
             }
         }
     }

--- a/Controls/Grid/Grid.UWP/View/RadDataGrid.Manipulation.cs
+++ b/Controls/Grid/Grid.UWP/View/RadDataGrid.Manipulation.cs
@@ -196,7 +196,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
 
             this.ResetSelectedHeader();
 
-            this.TryFocus(FocusState.Pointer, false);
+            this.TryFocus(FocusState.Pointer, false, e.OriginalSource as FrameworkElement);
 
             if (this.contentFlyout.IsOpen)
             {
@@ -254,7 +254,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
             this.ExecuteKeyDown(e);
         }
 
-        internal void TryFocus(FocusState state, bool force)
+        internal void TryFocus(FocusState state, bool force, FrameworkElement tappedElement = null)
         {
             if (!this.IsTabStop)
             {
@@ -268,7 +268,8 @@ namespace Telerik.UI.Xaml.Controls.Grid
             else
             {
                 var focusedElement = FocusManager.GetFocusedElement() as DependencyObject;
-                if (focusedElement == null || ElementTreeHelper.FindVisualAncestor<DataGridCellsPanel>(focusedElement) == null)
+                if (focusedElement == null || (ElementTreeHelper.FindVisualAncestor<DataGridCellsPanel>(focusedElement) == null 
+                    && ElementTreeHelper.FindVisualAncestor<DataGridCellsPanel>(tappedElement) == null))
                 {
                     this.Focus(state);
                 }


### PR DESCRIPTION
- Prevent moving the Focus back to the DataGrid if the OriginalSource that has been tapped in part of the VisualTree of the DataGridCellsPanel.
- Prevent clearing the selection from the ComboBox when items are selected by making the Binding of the SelectedValue Explicit and by updating in on LostFocus.
- If the DisplayMemberPath is null or empty do not call the GetRuntimeProperty in order to prevent throwing NullReferenceExceptio. 