### PR TITLE
Fix Accessibility issues

### DIFF
--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/Controls/DataFormNumericTextBox.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/Controls/DataFormNumericTextBox.cs
@@ -1,4 +1,8 @@
-﻿namespace Telerik.UI.Xaml.Controls.Data.DataForm
+﻿using Telerik.UI.Automation.Peers;
+using Telerik.UI.Xaml.Controls.Input;
+using Windows.UI.Xaml.Automation.Peers;
+
+namespace Telerik.UI.Xaml.Controls.Data.DataForm
 {
     /// <summary>
     /// Represents a DataFormNumericTextBox control.
@@ -11,6 +15,18 @@
         public DataFormNumericTextBox()
         {
             this.DefaultStyleKey = typeof(DataFormNumericTextBox);
+        }
+
+        /// <inheritdoc />
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            RadNumericBox parent = ElementTreeHelper.FindVisualAncestor<RadNumericBox>(this);
+            if (parent != null)
+            {
+                return new NumericTextBoxAutomationPeer(this, parent);
+            }
+
+            return base.OnCreateAutomationPeer();
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/ListView/AutomationPeers/RadListViewItemAutomationPeer.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/AutomationPeers/RadListViewItemAutomationPeer.cs
@@ -106,6 +106,7 @@ namespace Telerik.UI.Automation.Peers
                     this.ListViewItemOwner.ListView.SelectItem(this.ListViewItemOwner.Content);
                 }
                 this.RaisePropertyChangedEvent(SelectionItemPatternIdentifiers.IsSelectedProperty, false, true);
+                this.RaiseAutomationEvent(AutomationEvents.SelectionItemPatternOnElementSelected);
             }
         }
 
@@ -130,7 +131,7 @@ namespace Telerik.UI.Automation.Peers
         {
             return this.Owner.GetType().Name;
         }
-
+        
         /// <inheritdoc />
         protected override string GetLocalizedControlTypeCore()
         {

--- a/Controls/Grid/Grid.UWP/Themes/Resources.xaml
+++ b/Controls/Grid/Grid.UWP/Themes/Resources.xaml
@@ -240,6 +240,7 @@
     </Style>
 
     <Style TargetType="primitivesCommon:InlineButton" x:Key="GridServiceButtonStyle">
+        <Setter Property="AutomationProperties.Name" Value="Filter"/>
         <Setter Property="Background" Value="{ThemeResource TelerikGridServiceButtonBackgroundBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource TelerikGridServiceButtonForegroundBrush}"/>
         <Setter Property="PointerOverBackgroundBrush" Value="{ThemeResource TelerikGridServiceButtonPointerOverBackgroundBrush}"/>
@@ -1565,7 +1566,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <localPrimitives:DataGridFilterComboBox x:Name="PART_OperatorCombo" HorizontalAlignment="Stretch" Grid.ColumnSpan="2"/>
-                        <TextBox IsTextPredictionEnabled="False" x:Name="PART_ValueBox" HorizontalAlignment="Stretch" Grid.Row="1" Margin="0,16,0,0"/>
+                        <TextBox IsTextPredictionEnabled="False" x:Name="PART_ValueBox" HorizontalAlignment="Stretch" Grid.Row="1" Margin="0,16,0,0" AutomationProperties.Name="FilterTextBox"/>
                         <ToggleButton x:Name="PART_CaseButton" Grid.Row="1" Grid.Column="1" Content="aA" 
                                       Margin="2,16,0,0" Style="{StaticResource TextFilterCaseButtonStyle}" 
                                       IsChecked="{TemplateBinding IsCaseSensitive}"/>

--- a/Controls/Input/Input.UWP/AutoCompleteBox/AutomationPeers/SuggestionItemAutomationPeer.cs
+++ b/Controls/Input/Input.UWP/AutoCompleteBox/AutomationPeers/SuggestionItemAutomationPeer.cs
@@ -1,5 +1,4 @@
-﻿using Telerik.UI.Xaml.Controls.Input;
-using Telerik.UI.Xaml.Controls.Input.AutoCompleteBox;
+﻿using Telerik.UI.Xaml.Controls.Input.AutoCompleteBox;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Automation.Provider;
 
@@ -10,8 +9,6 @@ namespace Telerik.UI.Automation.Peers
     /// </summary>
     public class SuggestionItemAutomationPeer : ListBoxItemAutomationPeer, IInvokeProvider
     {
-        private SuggestionItemsControl suggestionItemsControl;
-       
         /// <summary>
         /// Initializes a new instance of the SuggestionItemAutomationPeer class.
         /// </summary>
@@ -20,31 +17,7 @@ namespace Telerik.UI.Automation.Peers
             : base(owner)
         {
         }
-    
-        /// <summary>
-        /// Initializes a new instance of the SuggestionItemAutomationPeer class.
-        /// </summary>
-        /// <param name="owner">The SuggestionItem that is associated with this SuggestionItemAutomationPeer.</param>
-        /// <param name="parent">The SuggestionItemsControl that is parent of SuggestionItem.</param>
-        public SuggestionItemAutomationPeer(SuggestionItem owner, SuggestionItemsControl parent) 
-            : this(owner)
-        {
-            this.suggestionItemsControl = parent;
-        }
-
-        private RadAutoCompleteBox parentAutoCompleteBox
-        {
-            get
-            {
-                if (this.suggestionItemsControl != null)
-                {
-                    return this.suggestionItemsControl.owner;
-                }
-
-                return null;
-            }
-        }
-
+        
         private SuggestionItem SuggestionItem
         {
             get
@@ -58,17 +31,7 @@ namespace Telerik.UI.Automation.Peers
         /// </summary>
         public void Invoke()
         {
-            if (this.parentAutoCompleteBox != null && this.parentAutoCompleteBox.IsDropDownOpen)
-            {
-                this.parentAutoCompleteBox.UpdateTextFromPopupInteraction(this.SuggestionItem.DataItem);
-                this.parentAutoCompleteBox.IsDropDownOpen = false;
-
-                var autoCompleteTextBoxPeer = FrameworkElementAutomationPeer.FromElement(this.parentAutoCompleteBox.textbox) as TextBoxAutomationPeer;
-                if (autoCompleteTextBoxPeer != null)
-                {
-                    autoCompleteTextBoxPeer.RaiseAutomationEvent(AutomationEvents.AutomationFocusChanged);
-                }
-            }
+            this.SuggestionItem.OnItemTap();
         }
 
         /// <inheritdoc />

--- a/Controls/Input/Input.UWP/AutoCompleteBox/SuggestionItem.cs
+++ b/Controls/Input/Input.UWP/AutoCompleteBox/SuggestionItem.cs
@@ -256,7 +256,7 @@ namespace Telerik.UI.Xaml.Controls.Input.AutoCompleteBox
         /// <inheritdoc />
         protected override AutomationPeer OnCreateAutomationPeer()
         {
-            return new SuggestionItemAutomationPeer(this, this.owner);
+            return new SuggestionItemAutomationPeer(this);
         }
 
         private static Run GetRunFromStyle(HighlightStyle style)

--- a/Controls/Input/Input.UWP/Calendar/AutomationPeers/CalendarCellInfoBaseAutomationPeer.cs
+++ b/Controls/Input/Input.UWP/Calendar/AutomationPeers/CalendarCellInfoBaseAutomationPeer.cs
@@ -119,7 +119,7 @@ namespace Telerik.UI.Automation.Peers
 
             if (this.CellNode.Context != null && !string.IsNullOrEmpty(this.CellNode.Context.Date.ToString()))
             {
-                return this.CellNode.Context.Date.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture);
+                return this.CellNode.Context.Date.ToString("MM/dd/yyyy", CultureInfo.InvariantCulture);
             }
 
             return string.Empty;

--- a/Controls/Input/Input.UWP/Rating/AutomationPeers/RadRatingItemAutomationPeer.cs
+++ b/Controls/Input/Input.UWP/Rating/AutomationPeers/RadRatingItemAutomationPeer.cs
@@ -82,6 +82,12 @@ namespace Telerik.UI.Automation.Peers
         }
 
         /// <inheritdoc />
+        protected override bool HasKeyboardFocusCore()
+        {
+            return true;
+        }
+
+        /// <inheritdoc />
         protected override string GetLocalizedControlTypeCore()
         {
             return "rad rating item";

--- a/Controls/Input/Input.UWP/Rating/RadRating.cs
+++ b/Controls/Input/Input.UWP/Rating/RadRating.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Input;
 using Telerik.Core;
 using Telerik.UI.Automation.Peers;
@@ -1252,6 +1253,16 @@ namespace Telerik.UI.Xaml.Controls.Input
             if (peer != null)
             {
                 peer.RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, oldValue, newValue);
+
+                var ratingItem = this.Items.ElementAtOrDefault((int)newValue - 1) as RadRatingItem;
+                if (ratingItem != null)
+                {
+                    var ratingItemPeer = FrameworkElementAutomationPeer.FromElement(ratingItem);
+                    if (ratingItemPeer != null)
+                    {
+                        ratingItemPeer.RaiseAutomationEvent(AutomationEvents.AutomationFocusChanged);
+                    }
+                }
             }
         }
 

--- a/Controls/Input/Input.UWP/Themes/Generic.xaml
+++ b/Controls/Input/Input.UWP/Themes/Generic.xaml
@@ -359,6 +359,7 @@
     </Style>
 
     <Style TargetType="primitivesCommon:InlineButton" x:Key="NumericButtonIncreaseStyle" BasedOn="{StaticResource NumericBoxButtonBaseStyle}">
+        <Setter Property="AutomationProperties.Name" Value="NumericIncrease"/>
         <Setter Property="ClickMode" Value="Press" />
         <Setter Property="Padding" Value="9,2,9,4" />
         <Setter Property="BorderThickness" Value="2" />
@@ -381,6 +382,7 @@
     </Style>
 
     <Style TargetType="primitivesCommon:InlineButton" x:Key="NumericButtonDecreaseStyle" BasedOn="{StaticResource NumericButtonIncreaseStyle}">
+        <Setter Property="AutomationProperties.Name" Value="NumericDecrease"/>
         <Setter Property="Margin" Value="2,0" />
         <Setter Property="Content" Value="&#xE0A1;" />
     </Style>
@@ -538,6 +540,7 @@
                         </VisualStateManager.VisualStateGroups>
                         <Border x:Name="BorderElement" Background="{TemplateBinding Background}" Grid.ColumnSpan="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" />
                         <ScrollViewer x:Name="ContentElement"
+                                      AutomationProperties.AccessibilityView="Raw"
                                       HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
                                       HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                       IsTabStop="False"


### PR DESCRIPTION
1. AutoCompleteBox: Double tap does not select item when the narrator is running.
2. Calendar: The Narrator reads date from another month when moving to another day with the arrows.
3. Numeric: It is hard to get the focus inside the control via tapping when the Narrator is running.
4. BusyIndicator: Double Tap hides the control when the Narrator is running.
5. Numeric: Set meaningful names to the Up and Down buttons.
6. GridView: Set meaningful names to FilterButton and FilterTextBox.
7. DataForm: PageUp\Down dues not update the Narrator to say the new value of Numeric.
8. ListView: There is no indication to the Narrator when selection is performed.
9. Rating: There is no indication the the Narrator when selection is performed via the keyboard.
