### PR TITLE
Execute the logic for the toggling of the SideDrawer when Enter or Sp…

### DIFF
--- a/Controls/Primitives/Primitives.UWP/SideDrawer/Commands/SideDrawerKeyDownCommand.cs
+++ b/Controls/Primitives/Primitives.UWP/SideDrawer/Commands/SideDrawerKeyDownCommand.cs
@@ -15,9 +15,10 @@ namespace Telerik.UI.Xaml.Controls.Primitives.SideDrawer.Commands
 
             var e = parameter as KeyRoutedEventArgs;
 
-            if (e.Key == Windows.System.VirtualKey.Space || e.Key == Windows.System.VirtualKey.Enter)
+            if (e.OriginalSource is RadSideDrawer && (e.Key == Windows.System.VirtualKey.Space || e.Key == Windows.System.VirtualKey.Enter))
             {
                 this.Owner.ToggleDrawer();
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
…ace is pressed only when the OriginalSource is the SideDrawer itself. #129 