### PR TITLE
Make old BarSeries visuals get hide when the ItemsSource is changed a…

### DIFF
--- a/Controls/Chart/Chart.UWP/Visualization/Common/ContainerVisualsFactory.cs
+++ b/Controls/Chart/Chart.UWP/Visualization/Common/ContainerVisualsFactory.cs
@@ -47,8 +47,8 @@ namespace Telerik.UI.Xaml.Controls.Chart
             var pointTemplateSeries = visualElement as PointTemplateSeries;
             if (pointTemplateSeries != null)
             {
-                if (pointTemplateSeries is AreaSeries || pointTemplateSeries is PointSeries
-                    || pointTemplateSeries is PolarSeries || (pointTemplateSeries.GetType() == typeof(ScatterPointSeries)))
+                if (pointTemplateSeries is AreaSeries || pointTemplateSeries is PointSeries || pointTemplateSeries is SplineSeries
+                    || pointTemplateSeries is ScatterSplineSeries || pointTemplateSeries is PolarSeries || (pointTemplateSeries.GetType() == typeof(ScatterPointSeries)))
                 {
                     return false;
                 }

--- a/Controls/Chart/Chart.UWP/Visualization/Common/PointTemplateSeries.cs
+++ b/Controls/Chart/Chart.UWP/Visualization/Common/PointTemplateSeries.cs
@@ -463,16 +463,33 @@ namespace Telerik.UI.Xaml.Controls.Chart
                     }
                 }
             }
-            
-            while (index < this.realizedDataPointPresenters.Count)
-            {
-                var presenter = this.realizedDataPointPresenters[index];
-                if (presenter.Visibility == Visibility.Visible)
-                {
-                    presenter.Visibility = Visibility.Collapsed;
-                }
 
-                index++;
+
+            if (this.drawWithComposition)
+            {
+                while (index < this.realizedContainerVisuals.Count)
+                {
+                    var containerVisual = this.realizedContainerVisuals.Keys.ElementAtOrDefault(index);
+                    if (containerVisual != null && containerVisual.IsVisible)
+                    {
+                        containerVisual.IsVisible = false;
+                    }
+
+                    index++;
+                }
+            }
+            else
+            {
+                while (index < this.realizedDataPointPresenters.Count)
+                {
+                    var presenter = this.realizedDataPointPresenters[index];
+                    if (presenter.Visibility == Visibility.Visible)
+                    {
+                        presenter.Visibility = Visibility.Collapsed;
+                    }
+
+                    index++;
+                }
             }
         }
 


### PR DESCRIPTION
…t runtime and prevent drawing the spline series with Composition [much faster when geometry is used in this particular scenario].