### PR TITLE
LINQ optimizations, improved PrepareLineRenderVisual performance

### DIFF
--- a/Controls/Chart/Chart.UWP/AutomationPeers/Common/RadChartBaseAutomationPeer.cs
+++ b/Controls/Chart/Chart.UWP/AutomationPeers/Common/RadChartBaseAutomationPeer.cs
@@ -67,8 +67,8 @@ namespace Telerik.UI.Automation.Peers
                 }
             }
 
-            var emptyContentPresenter = ElementTreeHelper.EnumVisualDescendants(this.Owner, descendand => descendand is ContentPresenter)
-                .Where(presenter => presenter.Equals(this.OwningChart.emptyContentPresenter)).SingleOrDefault() as ContentPresenter;
+            var emptyContentPresenter = ElementTreeHelper
+                .EnumVisualDescendants(this.Owner, descendand => descendand is ContentPresenter).SingleOrDefault(presenter => presenter.Equals(this.OwningChart.emptyContentPresenter)) as ContentPresenter;
 
             if (emptyContentPresenter != null)
             {

--- a/Controls/Chart/Chart.UWP/Visualization/Behaviors/Selection/ChartSelectionBehavior.cs
+++ b/Controls/Chart/Chart.UWP/Visualization/Behaviors/Selection/ChartSelectionBehavior.cs
@@ -197,12 +197,7 @@ namespace Telerik.UI.Xaml.Controls.Chart
 
         private bool UpdateSelection()
         {
-            bool handled = false;
-
-            if (this.UpdateSeriesSelection())
-            {
-                handled = true;
-            }
+            var handled = this.UpdateSeriesSelection();
 
             foreach (ChartSeries series in this.chart.SeriesInternal)
             {

--- a/Controls/Chart/Chart.UWP/Visualization/CartesianChart/Series/Categorical/CandlestickSeries.cs
+++ b/Controls/Chart/Chart.UWP/Visualization/CartesianChart/Series/Categorical/CandlestickSeries.cs
@@ -108,9 +108,9 @@ namespace Telerik.UI.Xaml.Controls.Chart
             }
             else
             {
-                for (int i = 0; i < visual.Children.Count; i++)
+                foreach (var child in visual.Children)
                 {
-                    var childVisual = visual.Children.ElementAt(i) as SpriteVisual;
+                    var childVisual = child as SpriteVisual;
                     if (childVisual != null)
                     {
                         this.chart.ContainerVisualsFactory.SetCompositionColorBrush(childVisual, null, true);

--- a/Controls/Chart/Chart.UWP/Visualization/CartesianChart/Series/Categorical/OhlcSeriesBase.cs
+++ b/Controls/Chart/Chart.UWP/Visualization/CartesianChart/Series/Categorical/OhlcSeriesBase.cs
@@ -237,9 +237,9 @@ namespace Telerik.UI.Xaml.Controls.Chart
 
             if (paletteStroke != null)
             {
-                for (int i = 0; i < visual.Children.Count; i++)
+                foreach (var child in visual.Children)
                 {
-                    var childVisual = visual.Children.ElementAt(i) as SpriteVisual;
+                    var childVisual = child as SpriteVisual;
                     if (childVisual != null)
                     {
                         if (ohlcDataPoint != null && ohlcDataPoint.IsFalling && specialPaletteStroke != null)
@@ -255,9 +255,9 @@ namespace Telerik.UI.Xaml.Controls.Chart
             }
             else
             {
-                for (int i = 0; i < visual.Children.Count; i++)
+                foreach (var child in visual.Children)
                 {
-                    var childVisual = visual.Children.ElementAt(i) as SpriteVisual;
+                    var childVisual = child as SpriteVisual;
                     if (childVisual != null)
                     {
                         this.chart.ContainerVisualsFactory.SetCompositionColorBrush(childVisual, null, true);

--- a/Controls/Chart/Chart.UWP/Visualization/Common/ContainerVisualsFactory.cs
+++ b/Controls/Chart/Chart.UWP/Visualization/Common/ContainerVisualsFactory.cs
@@ -266,21 +266,41 @@ namespace Telerik.UI.Xaml.Controls.Chart
         protected internal virtual ContainerVisual PrepareLineRenderVisual(ContainerVisual containerVisual, IEnumerable<Point> points, Brush stroke, double strokeThickness)
         {
             containerVisual.Children.RemoveAll();
-            for (int i = 0; i < points.Count(); i++)
-            {
-                SpriteVisual childSpiteVisual = containerVisual.Compositor.CreateSpriteVisual();
-                var startPoint = points.ElementAt(i);
-                if (i + 1 < points.Count())
-                {
-                    var endPoint = points.ElementAt(i + 1);
-                    var angle = Math.Atan2(endPoint.Y - startPoint.Y, endPoint.X - startPoint.X) * (180.0 / Math.PI);
-                    var width = Math.Sqrt((Math.Pow(startPoint.X - endPoint.X, 2) + Math.Pow(startPoint.Y - endPoint.Y, 2)));
 
-                    childSpiteVisual.RotationAngleInDegrees = (float)angle;
+            using (var enumerator = points.GetEnumerator())
+            {
+                var haveStartPoint = false;
+                var startPoint = default(Point);
+
+                while (enumerator.MoveNext())
+                {
+                    var endPoint = enumerator.Current;
+
+                    if (!haveStartPoint)
+                    {
+                        startPoint = endPoint;
+                        if (!enumerator.MoveNext()) break;
+                        haveStartPoint = true;
+                        endPoint = enumerator.Current;
+                    }
+
+                    // draw the line if we have both points
+                    var childSpiteVisual = containerVisual.Compositor.CreateSpriteVisual();
+                    var angle = Math.Atan2(endPoint.Y - startPoint.Y, endPoint.X - startPoint.X) * (180.0 / Math.PI);
+                    var width = Math.Sqrt(Math.Pow(startPoint.X - endPoint.X, 2) + Math.Pow(startPoint.Y - endPoint.Y, 2));
+
+	                if (Math.Abs(angle) > 40)
+		                width += 2;
+	                else
+		                width++;
+
+					childSpiteVisual.RotationAngleInDegrees = (float)angle;
                     childSpiteVisual.Offset = new Vector3((float)startPoint.X, (float)startPoint.Y, 0);
                     childSpiteVisual.Size = new Vector2((float)width, (float)strokeThickness);
-                    this.SetCompositionColorBrush(childSpiteVisual, stroke);
+                    SetCompositionColorBrush(childSpiteVisual, stroke);
                     containerVisual.Children.InsertAtBottom(childSpiteVisual);
+
+                    startPoint = endPoint;
                 }
             }
 

--- a/Controls/Chart/Chart.UWP/Visualization/Common/Renderers/LineRenderer.cs
+++ b/Controls/Chart/Chart.UWP/Visualization/Common/Renderers/LineRenderer.cs
@@ -63,12 +63,13 @@ namespace Telerik.UI.Xaml.Controls.Chart
 
             Brush paletteStroke = this.GetPaletteBrush(this.StrokePart);
 
-            for (int i = 0; i < containerVisual.Children.Count; i++)
+            foreach (var child in containerVisual.Children)
             {
-                var childVisual = containerVisual.Children.ElementAt(i) as SpriteVisual;
+                var childVisual = child as SpriteVisual;
                 if (childVisual != null)
                 {
-                    if (paletteStroke != null)
+					// TODO: review, copy/paste error? paletteStroke is used any way
+					if (paletteStroke != null)
                     {
                         factory.SetCompositionColorBrush(childVisual, paletteStroke, true);
                     }

--- a/Controls/Data.UWP/Data/Engine/DataProviders/LocalDataSourceProvider.cs
+++ b/Controls/Data.UWP/Data/Engine/DataProviders/LocalDataSourceProvider.cs
@@ -246,7 +246,7 @@ namespace Telerik.Data.Core
 
         public override void SuspendPropertyChanges(object item)
         {
-            if (!this.deferredItemsChanges.Where(c => c.Item1.IsAlive && c.Item1.Target == item).Any())
+            if (!this.deferredItemsChanges.Any(c => c.Item1.IsAlive && c.Item1.Target == item))
             {
                 this.deferredItemsChanges.Add(new Tuple<WeakReference, List<PropertyChangedEventArgs>>(new WeakReference(item), new List<PropertyChangedEventArgs>()));
             }
@@ -254,7 +254,7 @@ namespace Telerik.Data.Core
 
         public override void ResumePropertyChanges(object item)
         {
-            var pair = this.deferredItemsChanges.Where(c => c.Item1.IsAlive && c.Item1.Target == item).FirstOrDefault();
+            var pair = this.deferredItemsChanges.FirstOrDefault(c => c.Item1.IsAlive && c.Item1.Target == item);
 
             this.deferredItemsChanges.RemoveAll(c => !c.Item1.IsAlive || c.Item1.Target == item);
 
@@ -648,7 +648,7 @@ namespace Telerik.Data.Core
 
         private void ProcessPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            var deferredInfo = this.deferredItemsChanges.Where(c => c.Item1.IsAlive && c.Item1.Target == sender).FirstOrDefault();
+            var deferredInfo = this.deferredItemsChanges.FirstOrDefault(c => c.Item1.IsAlive && c.Item1.Target == sender);
             if (deferredInfo != null)
             {
                 deferredInfo.Item2.Add(e);

--- a/Controls/Data.UWP/Data/Engine/EntityProviders/Entity.cs
+++ b/Controls/Data.UWP/Data/Engine/EntityProviders/Entity.cs
@@ -42,7 +42,7 @@ namespace Telerik.Data.Core
         /// <param name="propertyName">The specific name of the property.</param>
         public EntityProperty GetEntityProperty(string propertyName)
         {
-            var entityProperty = this.properties.Where((p) => p.PropertyName == propertyName).FirstOrDefault();
+            var entityProperty = this.properties.FirstOrDefault(p => p.PropertyName == propertyName);
 
             return entityProperty;
         }

--- a/Controls/Data.UWP/Data/IncrementalLoading/IncrementalLoadingCollection.cs
+++ b/Controls/Data.UWP/Data/IncrementalLoading/IncrementalLoadingCollection.cs
@@ -75,7 +75,7 @@ namespace Telerik.Core.Data
                     }
                 }
 
-                return new LoadMoreItemsResult()
+                return new LoadMoreItemsResult
                 {
                     Count = data != null ? (uint)data.Count() : 0,
                 };

--- a/Controls/DataControls/DataControls.UWP/ListView/Layout/Strategies/StaggeredLayoutStrategy.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/Layout/Strategies/StaggeredLayoutStrategy.cs
@@ -142,16 +142,7 @@ namespace Telerik.Data.Core.Layouts
         {
             List<GeneratedItemModel> containers;
             if (this.generatedContainers.TryGetValue(slot, out containers))
-            {
-                var visibleContainers = containers.Where((model) =>
-                {
-                    return model.ItemInfo.Id == id;
-                });
-                if (visibleContainers.Count() > 0)
-                {
-                    return visibleContainers.First();
-                }
-            }
+	            return containers.FirstOrDefault(model => model.ItemInfo.Id == id);
 
             return null;
         }

--- a/Controls/DataControls/DataControls.UWP/ListView/Layout/WrapLayout.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/Layout/WrapLayout.cs
@@ -808,7 +808,7 @@ namespace Telerik.Data.Core.Layouts
                 }
             }
 
-            if (this.LayoutStrategies.Where(c => c is PlaceholderStrategy).Any())
+            if (this.LayoutStrategies.Any(c => c is PlaceholderStrategy))
             {
                 if (currentColumnLength + this.DefaultItemOppositeLength > newValue)
                 {

--- a/Controls/DataControls/DataControls.UWP/ListView/Model/GridLayoutStrategy.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/Model/GridLayoutStrategy.cs
@@ -126,16 +126,7 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView.Model
         {
             List<GeneratedItemModel> containers;
             if (this.generatedContainers.TryGetValue(slot, out containers))
-            {
-                var visibleContainers = containers.Where((model) =>
-                {
-                    return model.ItemInfo.Id == id;
-                });
-                if (visibleContainers.Count() > 0)
-                {
-                    return visibleContainers.First();
-                }
-            }
+                return containers.FirstOrDefault(model => model.ItemInfo.Id == id);
 
             return null;
         }

--- a/Controls/DataControls/DataControls.UWP/ListView/Model/WrapLayoutStrategy.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/Model/WrapLayoutStrategy.cs
@@ -11,7 +11,7 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView.Model
     internal class WrapLayoutStrategy : BaseLayoutStrategy
     {
         private WrapLayout layout;
-        private HashSet<object> generatedContainerItems = new HashSet<object>();
+        private readonly HashSet<object> generatedContainerItems = new HashSet<object>();
 
         [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "These virtual calls do not rely on uninitialized base state.")]
         public WrapLayoutStrategy(ItemModelGenerator generator, IOrientedParentView owner, double defaultItemLength, double defaultItemOppositeLength) : base(generator, owner)
@@ -136,16 +136,7 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView.Model
         {
             List<GeneratedItemModel> containers;
             if (this.generatedContainers.TryGetValue(slot, out containers))
-            {
-                var visibleContainers = containers.Where((model) =>
-                     {
-                         return model.ItemInfo.Id == id;
-                     });
-                if (visibleContainers.Count() > 0)
-                {
-                    return visibleContainers.First();
-                }
-            }
+                return containers.FirstOrDefault(model => model.ItemInfo.Id == id);
 
             return null;
         }

--- a/Controls/DataControls/DataControls.UWP/ListView/View/RadListView.Reorder.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/View/RadListView.Reorder.cs
@@ -57,7 +57,7 @@ namespace Telerik.UI.Xaml.Controls.Data
         IReorderItem IReorderItemsHost.ElementAt(int index)
         {
             // TODO refactor to optimize
-            return this.childrenPanel.Children.OfType<IReorderItem>().Where(c => c.LogicalIndex == index).FirstOrDefault();
+            return this.childrenPanel.Children.OfType<IReorderItem>().FirstOrDefault(c => c.LogicalIndex == index);
         }
 
         void IReorderItemsHost.OnItemsReordered(IReorderItem sourceItem, IReorderItem destinationItem)

--- a/Controls/DataControls/DataControls.UWP/ListView/View/Services/ListViewAnimationService.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/View/Services/ListViewAnimationService.cs
@@ -19,9 +19,9 @@ namespace Telerik.UI.Xaml.Controls.Data
 
     internal class ListViewAnimationService : ServiceBase<RadListView>
     {
-        private List<object> scheduledItemsForAnimation = new List<object>();
-        private Dictionary<RadAnimation, Tuple<object, Action<object>>> runningAnimations = new Dictionary<RadAnimation, Tuple<object, Action<object>>>();
-        private List<IAnimated> scheduledModelsForRecycle = new List<IAnimated>();
+        private readonly List<object> scheduledItemsForAnimation = new List<object>();
+        private readonly Dictionary<RadAnimation, Tuple<object, Action<object>>> runningAnimations = new Dictionary<RadAnimation, Tuple<object, Action<object>>>();
+        private readonly List<IAnimated> scheduledModelsForRecycle = new List<IAnimated>();
 
         public ListViewAnimationService(RadListView owner)
             : base(owner)
@@ -30,7 +30,7 @@ namespace Telerik.UI.Xaml.Controls.Data
 
         internal void PlayCheckBoxLayerAnimation(UIElement element, bool forward, bool beforeItem, double itemLength)
         {
-            var checkBoxanimation = new RadMoveAnimation() { Duration = TimeSpan.FromSeconds(0.3), FillBehavior = AnimationFillBehavior.HoldEnd };
+            var checkBoxanimation = new RadMoveAnimation { Duration = TimeSpan.FromSeconds(0.3), FillBehavior = AnimationFillBehavior.HoldEnd };
             checkBoxanimation.EndPoint = new Point(0, 0);
             itemLength = itemLength == 0 ? 29 : itemLength;
             var offset = beforeItem ? itemLength : -itemLength;
@@ -46,7 +46,7 @@ namespace Telerik.UI.Xaml.Controls.Data
 
         internal void PlayCheckModeAnimation(UIElement element, bool forward, bool beforeItem, double itemLength)
         {
-            var animation = new RadMoveAnimation() { Duration = TimeSpan.FromSeconds(0.3), FillBehavior = AnimationFillBehavior.HoldEnd };
+            var animation = new RadMoveAnimation { Duration = TimeSpan.FromSeconds(0.3), FillBehavior = AnimationFillBehavior.HoldEnd };
             animation.StartPoint = new Point(0, 0);
             itemLength = itemLength == 0 ? 29 : itemLength;
             var offset = beforeItem ? itemLength : -itemLength;
@@ -68,20 +68,11 @@ namespace Telerik.UI.Xaml.Controls.Data
         
         internal bool IsAnimating(ItemInfo? info)
         {
-            var models = this.runningAnimations.Values.Where((tuple) =>
-                {
-                    var model = tuple.Item1 as GeneratedItemModel;
-                    if (model != null && model.ItemInfo.Equals(info))
-                    {
-                        return true;
-                    }
-                    return false;
-                });
-            if (models.Count() > 0)
-            {
-                return true;
-            }
-            return false;
+	        return this.runningAnimations.Values.Any(tuple =>
+	        {
+		        var model = tuple.Item1 as GeneratedItemModel;
+		        return model != null && model.ItemInfo.Equals(info);
+	        });
         }
 
         internal bool HasItemsForAnimation()

--- a/Controls/DataVisualization/DataVisualization.UWP/Gauges/AutomationPeers/RadGaugeAutomationPeer.cs
+++ b/Controls/DataVisualization/DataVisualization.UWP/Gauges/AutomationPeers/RadGaugeAutomationPeer.cs
@@ -27,13 +27,13 @@ namespace Telerik.UI.Automation.Peers
         {
             get
             {
-                var arrowIndicator = this.Gauge.Indicators.Where(a => a is ArrowGaugeIndicator).FirstOrDefault();
+                var arrowIndicator = this.Gauge.Indicators.FirstOrDefault(a => a is ArrowGaugeIndicator);
                 if (arrowIndicator != null)
                 {
                     return arrowIndicator.Value;
                 }
 
-                var markerIndicator = this.Gauge.Indicators.Where(a => a is MarkerGaugeIndicator).FirstOrDefault();
+                var markerIndicator = this.Gauge.Indicators.FirstOrDefault(a => a is MarkerGaugeIndicator);
                 if (markerIndicator != null)
                 {
                     return markerIndicator.Value;
@@ -41,7 +41,7 @@ namespace Telerik.UI.Automation.Peers
 
                 if (this.Gauge is RadLinearGauge)
                 {
-                    var linearIndicator = this.Gauge.Indicators.Where(a => a is LinearBarGaugeIndicator).FirstOrDefault();
+                    var linearIndicator = this.Gauge.Indicators.FirstOrDefault(a => a is LinearBarGaugeIndicator);
                     if (linearIndicator != null)
                     {
                         return linearIndicator.Value;
@@ -50,7 +50,7 @@ namespace Telerik.UI.Automation.Peers
 
                 if (this.Gauge is RadRadialGauge)
                 {
-                    var radialIndicator = this.Gauge.Indicators.Where(a => a is RadialBarGaugeIndicator).FirstOrDefault();
+                    var radialIndicator = this.Gauge.Indicators.FirstOrDefault(a => a is RadialBarGaugeIndicator);
                     if (radialIndicator != null)
                     {
                         return radialIndicator.Value;

--- a/Controls/Grid/Grid.UWP/AutomationPeers/DataGridCellInfoAutomationPeer.cs
+++ b/Controls/Grid/Grid.UWP/AutomationPeers/DataGridCellInfoAutomationPeer.cs
@@ -40,7 +40,7 @@ namespace Telerik.UI.Automation.Peers
         {
             get
             {
-                var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).Where(a => a.Column.ItemInfo.Slot == this.column).FirstOrDefault();
+                var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).FirstOrDefault(a => a.Column.ItemInfo.Slot == this.column);
                 if (cell != null && this.radDataGrid.SelectionMode != DataGridSelectionMode.None)
                 {
                     if (this.radDataGrid.SelectionMode == DataGridSelectionMode.Single)
@@ -202,7 +202,7 @@ namespace Telerik.UI.Automation.Peers
         /// </summary>
         public void RemoveFromSelection()
         {
-            var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).Where(a => a.Column.ItemInfo.Slot == this.column).FirstOrDefault();
+            var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).FirstOrDefault(a => a.Column.ItemInfo.Slot == this.column);
             if (cell != null)
             {
                 if (this.radDataGrid.SelectionUnit == DataGridSelectionUnit.Row)
@@ -229,7 +229,7 @@ namespace Telerik.UI.Automation.Peers
         /// </summary>
         public void Invoke()
         {
-            var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).Where(a => a.Column.ItemInfo.Slot == this.column).FirstOrDefault();
+            var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).FirstOrDefault(a => a.Column.ItemInfo.Slot == this.column);
             if (cell != null)
             {
                 this.radDataGrid.BeginEdit(new DataGridCellInfo(cell), ActionTrigger.DoubleTap, null);
@@ -322,7 +322,7 @@ namespace Telerik.UI.Automation.Peers
         /// <inheritdoc />
         protected override string GetNameCore()
         {
-            var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).Where(a => a.Column.ItemInfo.Slot == this.column).FirstOrDefault();
+            var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).FirstOrDefault(a => a.Column.ItemInfo.Slot == this.column);
             if (cell != null && cell.Value != null)
             {
                 return cell.Value.ToString();
@@ -339,8 +339,8 @@ namespace Telerik.UI.Automation.Peers
                 var dataGridPeer = FrameworkElementAutomationPeer.FromElement(this.radDataGrid) as RadDataGridAutomationPeer;
                 if (dataGridPeer != null)
                 {
-                    var firstCellInRow = dataGridPeer.childrenCache.Where(a => a.Row == this.Row && a.Column == 0).FirstOrDefault();
-                    var lastCellInRow = dataGridPeer.childrenCache.Where(a => a.Row == this.Row && a.Column == (this.radDataGrid.Columns.Count - 1)).FirstOrDefault();
+                    var firstCellInRow = dataGridPeer.childrenCache.FirstOrDefault(a => a.Row == this.Row && a.Column == 0);
+                    var lastCellInRow = dataGridPeer.childrenCache.FirstOrDefault(a => a.Row == this.Row && a.Column == (this.radDataGrid.Columns.Count - 1));
 
                     if (firstCellInRow != null && lastCellInRow != null && firstCellInRow.ChildTextBlockPeer != null
                         && lastCellInRow.ChildTextBlockPeer != null)
@@ -418,7 +418,7 @@ namespace Telerik.UI.Automation.Peers
 
         private void SelectCell()
         {
-            var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).Where(a => a.Column.ItemInfo.Slot == this.column).FirstOrDefault();
+            var cell = this.radDataGrid.Model.CellsController.GetCellsForRow(this.row).FirstOrDefault(a => a.Column.ItemInfo.Slot == this.column);
             if (cell != null)
             {
                 this.radDataGrid.OnCellTap(new DataGridCellInfo(cell));

--- a/Controls/Grid/Grid.UWP/AutomationPeers/DataGridCellsPanelAutomationPeer.cs
+++ b/Controls/Grid/Grid.UWP/AutomationPeers/DataGridCellsPanelAutomationPeer.cs
@@ -76,12 +76,11 @@ namespace Telerik.UI.Automation.Peers
             List<AutomationPeer> dataGridContentLayerPanelChildren = new List<AutomationPeer>();
 
             var dataGridCellsPanelAutomationPeerChildren = base.GetChildrenCore();
-            DataGridContentLayerPanelAutomationPeer dataGridContentLayerPanelPeer = null;
 
-            if (dataGridCellsPanelAutomationPeerChildren.Count > 0)
+	        if (dataGridCellsPanelAutomationPeerChildren.Count > 0)
             {
-                dataGridContentLayerPanelPeer = dataGridCellsPanelAutomationPeerChildren.Where(a => a.GetName() == nameof(DataGridContentLayerPanel)).FirstOrDefault() as DataGridContentLayerPanelAutomationPeer;
-                if (dataGridContentLayerPanelPeer != null)
+	            var dataGridContentLayerPanelPeer = dataGridCellsPanelAutomationPeerChildren.FirstOrDefault(a => a.GetName() == nameof(DataGridContentLayerPanel)) as DataGridContentLayerPanelAutomationPeer;
+	            if (dataGridContentLayerPanelPeer != null)
                 {
                     dataGridContentLayerPanelChildren = dataGridContentLayerPanelPeer.GetChildren().ToList();
                 }
@@ -96,11 +95,11 @@ namespace Telerik.UI.Automation.Peers
                     foreach (var row in rows)
                     {
                         var cellsForRow = this.dataGrid.Model.CellsController.GetCellsForRow(row.Slot);
-                        if (cellsForRow.Count() > 0)
+                        if (cellsForRow.Any())
                         {
                             foreach (var cell in cellsForRow)
                             {
-                                DataGridCellInfoAutomationPeer peer = dataGridPeers.childrenCache.Where(a => a.Row == row.Slot && a.Column == cell.Column.ItemInfo.Slot).FirstOrDefault();
+                                DataGridCellInfoAutomationPeer peer = dataGridPeers.childrenCache.FirstOrDefault(a => a.Row == row.Slot && a.Column == cell.Column.ItemInfo.Slot);
                                 if (peer == null)
                                 {
                                     peer = new DataGridCellInfoAutomationPeer(row.Slot, cell.Column.ItemInfo.Slot, dataGridPeers, row.Item);

--- a/Controls/Grid/Grid.UWP/AutomationPeers/RadDataGridAutomationPeer.cs
+++ b/Controls/Grid/Grid.UWP/AutomationPeers/RadDataGridAutomationPeer.cs
@@ -123,16 +123,13 @@ namespace Telerik.UI.Automation.Peers
             }
 
             var cellsForRow = this.OwnerDataGrid.Model.CellsController.GetCellsForRow(rowIndex);
-            if (cellsForRow.Count() > 0)
+            var cell = cellsForRow.FirstOrDefault(a => a.Column.ItemInfo.Slot == columnIndex);
+            if (cell != null)
             {
-                var cell = cellsForRow.Where(a => a.Column.ItemInfo.Slot == columnIndex).FirstOrDefault();
-                if (cell != null)
+                var gridCellInfoPeer = this.childrenCache.First(a => a.Row == cell.ParentRow.ItemInfo.Slot && a.Column == cell.Column.ItemInfo.Slot);
+                if (gridCellInfoPeer != null)
                 {
-                    var gridCellInfoPeer = this.childrenCache.Where(a => a.Row == cell.ParentRow.ItemInfo.Slot && a.Column == cell.Column.ItemInfo.Slot).First() as DataGridCellInfoAutomationPeer;
-                    if (gridCellInfoPeer != null)
-                    {
-                        return this.ProviderFromPeer(gridCellInfoPeer);
-                    }
+                    return this.ProviderFromPeer(gridCellInfoPeer);
                 }
             }
 
@@ -147,7 +144,7 @@ namespace Telerik.UI.Automation.Peers
             var groupHeadersHost = this.OwnerDataGrid.GroupHeadersHost as Panel;
             if (groupHeadersHost != null && groupHeadersHost.Children.Count > 0)
             {
-                var dataGridContentLayerPanel = groupHeadersHost.Children.Where(a => a is DataGridContentLayerPanel).FirstOrDefault() as DataGridContentLayerPanel;
+                var dataGridContentLayerPanel = groupHeadersHost.Children.FirstOrDefault(a => a is DataGridContentLayerPanel) as DataGridContentLayerPanel;
                 if (dataGridContentLayerPanel != null)
                 {
                     IRawElementProviderSimple[] providers = new IRawElementProviderSimple[dataGridContentLayerPanel.Children.Count];
@@ -185,7 +182,7 @@ namespace Telerik.UI.Automation.Peers
                     {
                         if (selectedCellInfo != null)
                         {
-                            var gridCellInfoPeer = this.childrenCache.Where(a => a.Row == selectedCellInfo.RowItemInfo.Slot && a.Column == selectedCellInfo.Column.ItemInfo.Slot).First() as DataGridCellInfoAutomationPeer;
+                            var gridCellInfoPeer = this.childrenCache.First(a => a.Row == selectedCellInfo.RowItemInfo.Slot && a.Column == selectedCellInfo.Column.ItemInfo.Slot) as DataGridCellInfoAutomationPeer;
                             if (gridCellInfoPeer != null)
                             {
                                 providerSamples.Add(this.ProviderFromPeer(gridCellInfoPeer));
@@ -200,14 +197,11 @@ namespace Telerik.UI.Automation.Peers
                         if (selectedItem != null)
                         {
                             var gridCellInfoPeers = this.childrenCache.Where(a => a.Item == selectedItem);
-                            if (gridCellInfoPeers.Count() > 0)
+                            foreach (var gridCellInfoPeer in gridCellInfoPeers)
                             {
-                                foreach (var gridCellInfoPeer in gridCellInfoPeers)
+                                if (gridCellInfoPeer != null)
                                 {
-                                    if (gridCellInfoPeer != null)
-                                    {
-                                        providerSamples.Add(this.ProviderFromPeer(gridCellInfoPeer));
-                                    }
+                                    providerSamples.Add(this.ProviderFromPeer(gridCellInfoPeer));
                                 }
                             }
                         }
@@ -283,13 +277,13 @@ namespace Telerik.UI.Automation.Peers
                 || x.GetClassName() == nameof(Telerik.UI.Xaml.Controls.Grid.Primitives.SelectionRegionBackgroundControl)
                 || x.GetClassName() == nameof(Telerik.UI.Xaml.Controls.Grid.Primitives.DataGridCurrencyControl));
 
-                var scrollViewerPeer = children.Where(x => x.GetClassName() == nameof(ScrollViewer)).FirstOrDefault();
+                var scrollViewerPeer = children.FirstOrDefault(x => x.GetClassName() == nameof(ScrollViewer));
                 if (scrollViewerPeer != null)
                 {
                     var scrollViewerChildren = scrollViewerPeer.GetChildren();
                     if (scrollViewerChildren.Count > 0)
                     {
-                        var dataGridCellsPanelPeer = scrollViewerChildren.Where(a => a.GetClassName() == nameof(DataGridCellsPanel)).FirstOrDefault();
+                        var dataGridCellsPanelPeer = scrollViewerChildren.FirstOrDefault(a => a.GetClassName() == nameof(DataGridCellsPanel));
                         if (dataGridCellsPanelPeer != null)
                         {
                             dataGridCellsPanelPeer.GetChildren();

--- a/Controls/Grid/Grid.UWP/Model/GridModel.Layout.cs
+++ b/Controls/Grid/Grid.UWP/Model/GridModel.Layout.cs
@@ -229,7 +229,7 @@ namespace Telerik.UI.Xaml.Controls.Grid.Model
 
         internal GridCellEditorModel GetCellEditorModel(object container)
         {
-            return this.CellEditorsController.GetCellsForRow(1).Where(c => c.EditorHost == container).FirstOrDefault();
+            return this.CellEditorsController.GetCellsForRow(1).FirstOrDefault(c => c.EditorHost == container);
         }
 
         internal bool IsColumnIndexInView(ScrollIntoViewOperation<int> operation)

--- a/Controls/Grid/Grid.UWP/Model/GridModel.Table.cs
+++ b/Controls/Grid/Grid.UWP/Model/GridModel.Table.cs
@@ -284,13 +284,13 @@ namespace Telerik.UI.Xaml.Controls.Grid.Model
 
             var scrollableElements = this.ColumnPool.GetUnfrozenDisplayedElements();
 
-            if (frozenЕlements.Count() > 0)
+            if (frozenЕlements.Any())
             {
                 frozenColumnsOffset = frozenЕlements.Last().Value.Last().LayoutSlot.Right;
                 frozenRect = new RadRect(0, this.PhysicalVerticalOffset, frozenColumnsOffset, finalSize.Height);
             }
 
-            if (scrollableElements.Count() > 0)
+            if (scrollableElements.Any())
             {
                 var scrollableViewPortRight = scrollableElements.Last().Value.Last().layoutSlot.Right;
                 rect = new RadRect(this.PhysicalHorizontalOffset + frozenColumnsOffset, this.PhysicalVerticalOffset, scrollableViewPortRight, finalSize.Height);

--- a/Controls/Grid/Grid.UWP/View/Columns/DataGridColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/DataGridColumn.cs
@@ -608,7 +608,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
 
             if (descriptor is FilterDescriptorBase)
             {
-                this.isFiltered = this.Model.FilterDescriptors.Where(d => d.DescriptorPeer == this).FirstOrDefault() != descriptor;
+                this.isFiltered = this.Model.FilterDescriptors.FirstOrDefault(d => d.DescriptorPeer == this) != descriptor;
 
                 this.UpdateFilterVisualState(this.isFiltered);
             }

--- a/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridTypedColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridTypedColumn.cs
@@ -189,7 +189,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
             get
             {
                 if (this.Model != null &&
-                    this.Model.GroupDescriptors.OfType<PropertyGroupDescriptor>().Where(c => c.PropertyName == this.PropertyName).Any())
+                    this.Model.GroupDescriptors.OfType<PropertyGroupDescriptor>().Any(c => c.PropertyName == this.PropertyName))
                 {
                     return false;
                 }

--- a/Controls/Grid/Grid.UWP/View/Controls/ColumnHeaders/DataGridColumnHeaderPanel.DragDrop.cs
+++ b/Controls/Grid/Grid.UWP/View/Controls/ColumnHeaders/DataGridColumnHeaderPanel.DragDrop.cs
@@ -25,7 +25,7 @@ namespace Telerik.UI.Xaml.Controls.Grid.Primitives
 
         IReorderItem IReorderItemsHost.ElementAt(int index)
         {
-            return this.Children.OfType<IReorderItem>().Where(c => c.LogicalIndex == index).FirstOrDefault();
+            return this.Children.OfType<IReorderItem>().FirstOrDefault(c => c.LogicalIndex == index);
         }
 
         void IReorderItemsHost.OnItemsReordered(IReorderItem sourceItem, IReorderItem destinationItem)

--- a/Controls/Grid/Grid.UWP/View/Controls/DataGridFlyout.DragDrop.cs
+++ b/Controls/Grid/Grid.UWP/View/Controls/DataGridFlyout.DragDrop.cs
@@ -28,7 +28,7 @@ namespace Telerik.UI.Xaml.Controls.Grid.Primitives
 
         IReorderItem IReorderItemsHost.ElementAt(int index)
         {
-            return this.container.Children.OfType<IReorderItem>().Where(c => c.LogicalIndex == index).FirstOrDefault();
+            return this.container.Children.OfType<IReorderItem>().FirstOrDefault(c => c.LogicalIndex == index);
         }
 
         void IReorderItemsHost.OnItemsReordered(IReorderItem sourceItem, IReorderItem destinationItem)

--- a/Controls/Grid/Grid.UWP/View/RadDataGrid.Manipulation.cs
+++ b/Controls/Grid/Grid.UWP/View/RadDataGrid.Manipulation.cs
@@ -79,7 +79,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
             {
                 FirstFilterControl = header.Column.CreateFilterControl(),
                 Column = header.Column,
-                AssociatedDescriptor = this.FilterDescriptors.Where(d => d.DescriptorPeer == header.Column).FirstOrDefault()
+                AssociatedDescriptor = this.FilterDescriptors.FirstOrDefault(d => d.DescriptorPeer == header.Column)
             };
 
             if (header.Column.SupportsCompositeFilter)
@@ -498,7 +498,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
                     dataGridPeer.GetChildren();
                 }
 
-                var cellPeer = dataGridPeer.childrenCache.Where(a => a.Row == info.Value.Slot && a.Column == 0).FirstOrDefault() as DataGridCellInfoAutomationPeer;
+                var cellPeer = dataGridPeer.childrenCache.FirstOrDefault(a => a.Row == info.Value.Slot && a.Column == 0) as DataGridCellInfoAutomationPeer;
                 if (cellPeer != null && cellPeer.ChildTextBlockPeer != null)
                 {
                     cellPeer.RaiseAutomationEvent(AutomationEvents.AutomationFocusChanged);

--- a/Controls/Grid/Grid.UWP/View/RadDataGrid.Selection.cs
+++ b/Controls/Grid/Grid.UWP/View/RadDataGrid.Selection.cs
@@ -139,7 +139,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
             var dataGridPeer = FrameworkElementAutomationPeer.FromElement(this) as RadDataGridAutomationPeer;
             if (dataGridPeer != null && dataGridPeer.childrenCache != null && dataGridPeer.childrenCache.Count > 0)
             {
-                var cellPeer = dataGridPeer.childrenCache.Where(a => a.Item == item).FirstOrDefault() as DataGridCellInfoAutomationPeer;
+                var cellPeer = dataGridPeer.childrenCache.FirstOrDefault(a => a.Item == item) as DataGridCellInfoAutomationPeer;
                 if (cellPeer != null && cellPeer.ChildTextBlockPeer != null)
                 {
                     cellPeer.RaiseValuePropertyChangedEvent(true, false);
@@ -168,7 +168,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
             var dataGridPeer = FrameworkElementAutomationPeer.FromElement(this) as RadDataGridAutomationPeer;
             if (dataGridPeer != null && dataGridPeer.childrenCache != null && dataGridPeer.childrenCache.Count > 0)
             {
-                var cellPeer = dataGridPeer.childrenCache.Where(a => a.Row == item.RowItemInfo.Slot && a.Column == item.Column.ItemInfo.Slot).FirstOrDefault() as DataGridCellInfoAutomationPeer;
+                var cellPeer = dataGridPeer.childrenCache.FirstOrDefault(a => a.Row == item.RowItemInfo.Slot && a.Column == item.Column.ItemInfo.Slot) as DataGridCellInfoAutomationPeer;
                 if (cellPeer != null && cellPeer.ChildTextBlockPeer != null)
                 {
                     cellPeer.RaiseValuePropertyChangedEvent(true, false);

--- a/Controls/Grid/Grid.UWP/View/Services/Commands/ColumnHeader/ColumnHeaderActionCommand.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Commands/ColumnHeader/ColumnHeaderActionCommand.cs
@@ -73,7 +73,7 @@ namespace Telerik.UI.Xaml.Controls.Grid.Commands
                     var typedColumn = column as DataGridTypedColumn;
                     if (typedColumn != null)
                     {
-                        var descriptor = this.Owner.GroupDescriptors.OfType<PropertyGroupDescriptor>().Where(d => d.PropertyName == typedColumn.PropertyName).FirstOrDefault();
+                        var descriptor = this.Owner.GroupDescriptors.OfType<PropertyGroupDescriptor>().FirstOrDefault(d => d.PropertyName == typedColumn.PropertyName);
                         if (descriptor != null)
                         {
                             this.Owner.GroupDescriptors.Remove(descriptor);

--- a/Controls/Grid/Grid.UWP/View/Services/Selection/SelectionService.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Selection/SelectionService.cs
@@ -76,7 +76,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
                     dataGridPeer.GetChildren();
                 }
 
-                var cellPeer = dataGridPeer.childrenCache.Where(a => a.Row == gridCellModel.ParentRow.ItemInfo.Slot && a.Column == gridCellModel.Column.ItemInfo.Slot).FirstOrDefault() as DataGridCellInfoAutomationPeer;
+                var cellPeer = dataGridPeer.childrenCache.FirstOrDefault(a => a.Row == gridCellModel.ParentRow.ItemInfo.Slot && a.Column == gridCellModel.Column.ItemInfo.Slot) as DataGridCellInfoAutomationPeer;
                 if (cellPeer != null && cellPeer.ChildTextBlockPeer != null)
                 {
                     await Dispatcher.RunAsync(

--- a/Controls/Input/Input.UWP/Calendar/AutomationPeers/CalendarViewHostAutomationPeer.cs
+++ b/Controls/Input/Input.UWP/Calendar/AutomationPeers/CalendarViewHostAutomationPeer.cs
@@ -81,8 +81,8 @@ namespace Telerik.UI.Automation.Peers
 
             foreach (CalendarCellModel cellModel in this.CalendarOwner.Model.currentViewModel.CalendarCells)
             {
-                CalendarCellInfoBaseAutomationPeer peer = calendarPeer.childrenCache.OfType<CalendarCellInfoBaseAutomationPeer>()
-                                .Where(a => this.AreModelsEqual(a.CellNode, cellModel)).FirstOrDefault();
+                CalendarCellInfoBaseAutomationPeer peer = calendarPeer.childrenCache
+                                .OfType<CalendarCellInfoBaseAutomationPeer>().FirstOrDefault(a => this.AreModelsEqual(a.CellNode, cellModel));
 
                 if (peer == null)
                 {
@@ -105,8 +105,8 @@ namespace Telerik.UI.Automation.Peers
             {
                 foreach (CalendarHeaderCellModel headerModel in monthModel.CalendarHeaderCells)
                 {
-                    CalendarHeaderCellInfoAutomationPeer peer = calendarPeer.childrenCache.OfType<CalendarHeaderCellInfoAutomationPeer>()
-                        .Where(a => this.AreHeaderModelsEqual(a.HeaderCellModel, headerModel)).FirstOrDefault();
+                    CalendarHeaderCellInfoAutomationPeer peer = calendarPeer.childrenCache
+                        .OfType<CalendarHeaderCellInfoAutomationPeer>().FirstOrDefault(a => this.AreHeaderModelsEqual(a.HeaderCellModel, headerModel));
 
                     if (peer == null)
                     {

--- a/Controls/Input/Input.UWP/Calendar/AutomationPeers/RadCalendarAutomationPeer.cs
+++ b/Controls/Input/Input.UWP/Calendar/AutomationPeers/RadCalendarAutomationPeer.cs
@@ -154,7 +154,7 @@ namespace Telerik.UI.Automation.Peers
         {
             string[] viewNames = Enum.GetNames(typeof(CalendarDisplayMode));
 
-            if (viewId < 0 || viewId >= viewNames.Count())
+            if (viewId < 0 || viewId >= viewNames.Length)
             {
                 return string.Empty;
             }
@@ -169,8 +169,8 @@ namespace Telerik.UI.Automation.Peers
         /// <param name="column">The index of the peer's column.</param>
         public IRawElementProviderSimple GetItem(int row, int column)
         {
-            CalendarSelectableCellnfoAutomationPeer peer = this.childrenCache.OfType<CalendarSelectableCellnfoAutomationPeer>()
-                .Where(x => (x.CellModel.RowIndex == row && x.CellModel.ColumnIndex == column)).FirstOrDefault();
+            CalendarSelectableCellnfoAutomationPeer peer = this.childrenCache
+                .OfType<CalendarSelectableCellnfoAutomationPeer>().FirstOrDefault(x => (x.CellModel.RowIndex == row && x.CellModel.ColumnIndex == column));
             if (peer != null)
             {
                 return this.ProviderFromPeer(peer);
@@ -335,10 +335,10 @@ namespace Telerik.UI.Automation.Peers
 
         private CalendarSelectableCellnfoAutomationPeer GetOrCreatePeerFromDateTime(DateTime date)
         {
-            CalendarSelectableCellnfoAutomationPeer peer = this.childrenCache.OfType<CalendarSelectableCellnfoAutomationPeer>().Where(x => x.CellModel.Date == date).FirstOrDefault();
+            CalendarSelectableCellnfoAutomationPeer peer = this.childrenCache.OfType<CalendarSelectableCellnfoAutomationPeer>().FirstOrDefault(x => x.CellModel.Date == date);
             if (peer == null && this.CalendarOwner.Model.CalendarCells != null)
             {
-                CalendarCellModel model = this.CalendarOwner.Model.CalendarCells.Where(cell => cell.Date == date).FirstOrDefault();
+                CalendarCellModel model = this.CalendarOwner.Model.CalendarCells.FirstOrDefault(cell => cell.Date == date);
                 if (model != null)
                 {
                     CalendarViewHostAutomationPeer hostPeer = (CalendarViewHostAutomationPeer)FrameworkElementAutomationPeer.FromElement(this.CalendarOwner.calendarViewHost);

--- a/Controls/Primitives/Primitives.UWP/BusyIndicator/RadBusyIndicator.cs
+++ b/Controls/Primitives/Primitives.UWP/BusyIndicator/RadBusyIndicator.cs
@@ -306,7 +306,7 @@ namespace Telerik.UI.Xaml.Controls.Primitives
 
             if (this.stylesCache[styleCacheIndex] == null)
             {
-                var resourceName = typeof(RadBusyIndicator).GetTypeInfo().Assembly.GetManifestResourceNames().Where(c => c.Contains(newValue.ToString())).First();
+                var resourceName = typeof(RadBusyIndicator).GetTypeInfo().Assembly.GetManifestResourceNames().First(c => c.Contains(newValue.ToString()));
                 
                 Stream stream = typeof(RadBusyIndicator).GetTypeInfo().Assembly.GetManifestResourceStream(resourceName);
 

--- a/Controls/Primitives/Primitives.UWP/RadialMenu/Model/Rings/RingModel.cs
+++ b/Controls/Primitives/Primitives.UWP/RadialMenu/Model/Rings/RingModel.cs
@@ -82,7 +82,7 @@ namespace Telerik.UI.Xaml.Controls.Primitives.Menu
                 return null;
             }
 
-            return this.Segments.Where(c => c.TargetItem == item).FirstOrDefault();
+            return this.Segments.FirstOrDefault(c => c.TargetItem == item);
         }
 
         internal virtual void UpdateItem(RadialSegment menuItem)

--- a/UnitTests/UAP.Tests/Grid.Tests/Data/GroupTestsHelper.cs
+++ b/UnitTests/UAP.Tests/Grid.Tests/Data/GroupTestsHelper.cs
@@ -93,9 +93,9 @@ namespace Telerik.UI.Xaml.Controls.Grid.Tests
             var flatRowGroups = results.Root.RowGroup.Flatten().ToList();
             var flatColumnGroups = results.Root.ColumnGroup.Flatten().ToList();
 
-            for (int i = 0; i < flatRowGroups.Count(); i++)
+            for (int i = 0; i < flatRowGroups.Count; i++)
             {
-                for (int j = 0; j < flatColumnGroups.Count(); j++)
+                for (int j = 0; j < flatColumnGroups.Count; j++)
                 {
                     var expectedValue = aggregates[i][j];
                     var rowGroup = flatRowGroups[i];

--- a/UnitTests/UAP.Tests/Grid.Tests/Data/Helpers/INotifyPropertyChangedExtensions.cs
+++ b/UnitTests/UAP.Tests/Grid.Tests/Data/Helpers/INotifyPropertyChangedExtensions.cs
@@ -51,7 +51,7 @@ namespace Telerik.UI.Xaml.Controls.Grid.Tests
 
             ParameterExpression senderParameter = Expression.Parameter(typeof(object), "sender");
 
-            var eventArgsType = eventInfo.EventHandlerType.GetRuntimeMethods().Where(mi => mi.Name == "Invoke").First().GetParameters()[1].ParameterType;
+            var eventArgsType = eventInfo.EventHandlerType.GetRuntimeMethods().First(mi => mi.Name == "Invoke").GetParameters()[1].ParameterType;
             ParameterExpression eventArgsParameter = Expression.Parameter(eventArgsType, "e");
 
             GenericEventHandler handler = new GenericEventHandler();
@@ -79,7 +79,7 @@ namespace Telerik.UI.Xaml.Controls.Grid.Tests
 
         private class GenericEventHandler
         {
-            public static MethodInfo MethodInfo = typeof(GenericEventHandler).GetRuntimeMethods().Where(mi => mi.Name =="OnEventTriggered").First();
+            public static MethodInfo MethodInfo = typeof(GenericEventHandler).GetRuntimeMethods().First(mi => mi.Name =="OnEventTriggered");
 
             public bool EventFired { get; private set; }
 

--- a/UnitTests/UAP.Tests/Grid.Tests/Data/PivotEngineTests.cs
+++ b/UnitTests/UAP.Tests/Grid.Tests/Data/PivotEngineTests.cs
@@ -1818,7 +1818,6 @@ namespace Telerik.UI.Xaml.Controls.Grid.Tests
                     // TODO: Probably this should be done in two different methods as the omited parentGroupNames somehow is hard to test and probably would cause further misunderstandings....
                     if (callbackCalls3 == 1)
                     {
-                        int count = parentGroupNames.Count();
                         IList<object> expectedParentNames = new List<object>() { new LevelName() { Level = 1, Name = "Product" } };
                         Assert.IsTrue(expectedParentNames.ItemsEqual(parentGroupNames), "Unexpected parent names.");
                     }
@@ -1845,7 +1844,6 @@ namespace Telerik.UI.Xaml.Controls.Grid.Tests
                     // TODO: Probably this should be done in two different methods as the omited parentGroupNames somehow is hard to test and probably would cause further misunderstandings....
                     if (callbackCalls4 == 1)
                     {
-                        int count = parentGroupNames.Count();
                         IList<object> expectedParentNames = new List<object>() { new LevelName() { Level = 2, Name = "Promotion" } };
                         Assert.IsTrue(expectedParentNames.ItemsEqual(parentGroupNames), "Unexpected parent names.");
                     }
@@ -1872,7 +1870,6 @@ namespace Telerik.UI.Xaml.Controls.Grid.Tests
                     // TODO: Probably this should be done in two different methods as the omited parentGroupNames somehow is hard to test and probably would cause further misunderstandings....
                     if (callbackCalls5 == 1)
                     {
-                        int count = parentGroupNames.Count();
                         IList<object> expectedParentNames = new List<object>() { new LevelName() { Level = 3, Name = "Product" }, new LevelName() { Level = 1, Name = "Product" } };
                         Assert.IsTrue(expectedParentNames.ItemsEqual(parentGroupNames), "Unexpected parent names.");
                     }

--- a/UnitTests/UAP.Tests/Input.Tests/Calendar/Services/DateRangeCollectionTests.cs
+++ b/UnitTests/UAP.Tests/Input.Tests/Calendar/Services/DateRangeCollectionTests.cs
@@ -29,12 +29,12 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(newRangesList.Count(), this.dateRangeCollection.Count(), "Date range merges occure");
+            Assert.AreEqual<int>(newRangesList.Count, this.dateRangeCollection.Count, "Date range merges occure");
 
-            for (int i = 0; i < this.dateRangeCollection.Count(); i++)
+            for (int i = 0; i < this.dateRangeCollection.Count; i++)
             {
-                Assert.AreEqual(newRangesList[i].StartDate, this.dateRangeCollection.ElementAt(i).StartDate);
-                Assert.AreEqual(newRangesList[i].EndDate, this.dateRangeCollection.ElementAt(i).EndDate);
+                Assert.AreEqual(newRangesList[i].StartDate, this.dateRangeCollection[i].StartDate);
+                Assert.AreEqual(newRangesList[i].EndDate, this.dateRangeCollection[i].EndDate);
             }
         }
 
@@ -51,12 +51,12 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(newRangesList.Count(), this.dateRangeCollection.Count(), "Date range merges occure");
+            Assert.AreEqual<int>(newRangesList.Count, this.dateRangeCollection.Count, "Date range merges occure");
 
-            for (int i = 0; i < this.dateRangeCollection.Count(); i++)
+            for (int i = 0; i < this.dateRangeCollection.Count; i++)
             {
-                Assert.AreEqual(newRangesList[i].StartDate, this.dateRangeCollection.ElementAt(i).StartDate);
-                Assert.AreEqual(newRangesList[i].EndDate, this.dateRangeCollection.ElementAt(i).EndDate);
+                Assert.AreEqual(newRangesList[i].StartDate, this.dateRangeCollection[i].StartDate);
+                Assert.AreEqual(newRangesList[i].EndDate, this.dateRangeCollection[i].EndDate);
             }
         }
 
@@ -72,12 +72,12 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
             {
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
-            Assert.AreEqual<int>(newRangesList.Count(), this.dateRangeCollection.Count(), "Date range merges occure");
+            Assert.AreEqual<int>(newRangesList.Count, this.dateRangeCollection.Count, "Date range merges occure");
 
             this.dateRangeCollection.AddDateRange(new CalendarDateRange(new DateTime(2013, 1, 2), new DateTime(2013, 1, 2)));
             this.dateRangeCollection.AddDateRange(new CalendarDateRange(new DateTime(2013, 1, 4), new DateTime(2013, 1, 4)));
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count(), "Date range merges occure");
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count, "Date range merges occure");
 
             Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection.FirstOrDefault().StartDate);
             Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection.FirstOrDefault().EndDate);
@@ -95,12 +95,12 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
             {
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
-            Assert.AreEqual<int>(newRangesList.Count(), this.dateRangeCollection.Count(), "Date range merges occure");
+            Assert.AreEqual<int>(newRangesList.Count, this.dateRangeCollection.Count, "Date range merges occure");
 
             this.dateRangeCollection.AddDateRange(new CalendarDateRange(new DateTime(2013, 1, 2, 13, 13, 13), new DateTime(2013, 1, 2, 15, 15, 15)));
             this.dateRangeCollection.AddDateRange(new CalendarDateRange(new DateTime(2013, 1, 4, 13, 13, 13), new DateTime(2013, 1, 4, 15, 15, 15)));
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count(), "Date range merges occure");
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count, "Date range merges occure");
 
             Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection.FirstOrDefault().StartDate);
             Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection.FirstOrDefault().EndDate);
@@ -119,9 +119,9 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
-            Assert.AreEqual(newRangesList[0].StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList[0].EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
+            Assert.AreEqual(newRangesList[0].StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList[0].EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -137,9 +137,9 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
-            Assert.AreEqual(newRangesList[0].StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList[0].EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
+            Assert.AreEqual(newRangesList[0].StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList[0].EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -155,9 +155,9 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
-            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
+            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -173,9 +173,9 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
-            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
+            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -191,9 +191,9 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
-            Assert.AreEqual(newRangesList[2].StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList[2].EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
+            Assert.AreEqual(newRangesList[2].StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList[2].EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -209,9 +209,9 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
-            Assert.AreEqual(newRangesList[2].StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList[2].EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
+            Assert.AreEqual(newRangesList[2].StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList[2].EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -227,9 +227,9 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
-            Assert.AreEqual(newRangesList[0].StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList[0].EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
+            Assert.AreEqual(newRangesList[0].StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList[0].EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -245,9 +245,9 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
-            Assert.AreEqual(newRangesList[0].StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList[0].EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
+            Assert.AreEqual(newRangesList[0].StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList[0].EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -263,10 +263,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
 
-            Assert.AreEqual(newRangesList.LastOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.FirstOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.FirstOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -282,10 +282,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
 
-            Assert.AreEqual(newRangesList.LastOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.FirstOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.FirstOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -302,10 +302,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
 
-            Assert.AreEqual(newRangesList.LastOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.FirstOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.FirstOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -322,10 +322,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
 
-            Assert.AreEqual(newRangesList.LastOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.FirstOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.FirstOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -342,10 +342,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
 
-            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -362,10 +362,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
 
-            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -383,10 +383,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
 
-            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
 
         [TestMethod]
@@ -404,10 +404,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Tests.Calendar.Services
                 this.dateRangeCollection.AddDateRange(dateRange);
             }
 
-            Assert.AreEqual<int>(1, this.dateRangeCollection.Count());
+            Assert.AreEqual<int>(1, this.dateRangeCollection.Count);
 
-            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection.ElementAt(0).StartDate);
-            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection.ElementAt(0).EndDate);
+            Assert.AreEqual(newRangesList.FirstOrDefault().StartDate, this.dateRangeCollection[0].StartDate);
+            Assert.AreEqual(newRangesList.LastOrDefault().EndDate, this.dateRangeCollection[0].EndDate);
         }
     }
 }


### PR DESCRIPTION
Optimized PrepareLineRenderVisual so that points enumerated only once, improved LINQ usage by removing expensive Count() and ElementAt() where possible, straightforward LINQ optimizations suggested by ReSharper, few other improvements.