### PR TITLE
Prevent throwing NullReferenceException when the Chart control doesn'…

### DIFF
--- a/Controls/Chart/Chart.UWP/Visualization/Behaviors/Trackball/ChartTrackBallBehavior.cs
+++ b/Controls/Chart/Chart.UWP/Visualization/Behaviors/Trackball/ChartTrackBallBehavior.cs
@@ -569,8 +569,9 @@ namespace Telerik.UI.Xaml.Controls.Chart
                     context = new ChartDataContext(points, context.ClosestDataPoint);
                 }
             }
-
-            if (context.ClosestDataPoint.DataPoint.LayoutSlot.X > this.chart.PlotAreaClip.X
+            
+            if (context.ClosestDataPoint != null 
+                && context.ClosestDataPoint.DataPoint.LayoutSlot.X > this.chart.PlotAreaClip.X
                 && context.ClosestDataPoint.DataPoint.LayoutSlot.X < (this.chart.PlotAreaClip.X + this.chart.PlotAreaClip.Width))
             {
                 this.UpdateLine(context);


### PR DESCRIPTION
…t have data present inside it. Issue: #154 