### PR TITLE
Replace the Segoe UI icon (used in Windows 8) in the LoadButton with …

### DIFF
--- a/Controls/Grid/Grid.UWP/Themes/Resources.xaml
+++ b/Controls/Grid/Grid.UWP/Themes/Resources.xaml
@@ -2060,14 +2060,23 @@
                         <Grid>
                             <primitivesCommon:InlineButton x:Name="PART_LoadButton" HorizontalAlignment="Stretch">
                                 <primitivesCommon:InlineButton.Content>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE0BA;" FontSize="18" RenderTransformOrigin="0.5,0.5" >
-                                            <TextBlock.RenderTransform>
-                                                <RotateTransform Angle="-90"/>
-                                            </TextBlock.RenderTransform>
-                                        </TextBlock>
-                                        <TextBlock Text="{Binding LoadMoreRowsText, RelativeSource={RelativeSource Mode=TemplatedParent}}" Margin="5 0 0 0"/>
-                                    </StackPanel>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                   Text="&#xE1FD;"
+                                                   FontSize="12"
+                                                   HorizontalAlignment="Center" 
+                                                   VerticalAlignment="Center"
+                                                   RenderTransformOrigin="0.5,0.5"/>
+                                        <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
+                                                   Text="&#xEA3A;" 
+                                                   FontSize="20" 
+                                                   RenderTransformOrigin="0.5,0.5"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding LoadMoreRowsText, RelativeSource={RelativeSource Mode=TemplatedParent}}" Margin="5 0 0 0"/>
+                                    </Grid>
                                 </primitivesCommon:InlineButton.Content>
                                 <primitivesCommon:InlineButton.Style>
                                     <Style TargetType="primitivesCommon:InlineButton">

--- a/Controls/Grid/Grid.UWP/Themes/Resources.xaml
+++ b/Controls/Grid/Grid.UWP/Themes/Resources.xaml
@@ -2060,23 +2060,14 @@
                         <Grid>
                             <primitivesCommon:InlineButton x:Name="PART_LoadButton" HorizontalAlignment="Stretch">
                                 <primitivesCommon:InlineButton.Content>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition/>
-                                            <ColumnDefinition/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                                   Text="&#xE1FD;"
-                                                   FontSize="12"
-                                                   HorizontalAlignment="Center" 
-                                                   VerticalAlignment="Center"
-                                                   RenderTransformOrigin="0.5,0.5"/>
-                                        <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                                                   Text="&#xEA3A;" 
-                                                   FontSize="20" 
-                                                   RenderTransformOrigin="0.5,0.5"/>
-                                        <TextBlock Grid.Column="1" Text="{Binding LoadMoreRowsText, RelativeSource={RelativeSource Mode=TemplatedParent}}" Margin="5 0 0 0"/>
-                                    </Grid>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe UI Symbol" Text="&#xE0BA;" FontSize="18" RenderTransformOrigin="0.5,0.5" >
+                                            <TextBlock.RenderTransform>
+                                                <RotateTransform Angle="-90"/>
+                                            </TextBlock.RenderTransform>
+                                        </TextBlock>
+                                        <TextBlock Text="{Binding LoadMoreRowsText, RelativeSource={RelativeSource Mode=TemplatedParent}}" Margin="5 0 0 0"/>
+                                    </StackPanel>
                                 </primitivesCommon:InlineButton.Content>
                                 <primitivesCommon:InlineButton.Style>
                                     <Style TargetType="primitivesCommon:InlineButton">


### PR DESCRIPTION
…a combined icon that uses the Segow MDL2 for Windows 10. #158 