### PR TITLE
Prevent throwing ArgumentOutOfRangeException for UWP calender by tryi…

### DIFF
--- a/Controls/Input/Input.UWP/Calendar/CalendarMathHelper.cs
+++ b/Controls/Input/Input.UWP/Calendar/CalendarMathHelper.cs
@@ -16,12 +16,24 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal static DateTime GetFirstDateOfDecade(DateTime date)
         {
-            return new DateTime((date.Year / 10) * 10, 1, 1);
+            var decadeYear = (date.Year / 10) * 10;
+            if (CouldAddYearsToDate(decadeYear))
+            {
+                return new DateTime(decadeYear, 1, 1);
+            }
+
+            return date;
         }
 
         internal static DateTime GetFirstDateOfCentury(DateTime date)
         {
-            return new DateTime((date.Year / 100) * 100, 1, 1);
+            var yearOfCentury = (date.Year / 100) * 100;
+            if (CouldAddYearsToDate(yearOfCentury))
+            {
+                return new DateTime(yearOfCentury, 1, 1);
+            }
+
+            return date;
         }
 
         internal static DateTime GetFirstDateForCurrentDisplayUnit(DateTime date, CalendarDisplayMode displayMode)
@@ -114,14 +126,21 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
             switch (displayMode)
             {
                 case CalendarDisplayMode.YearView:
-                    return date.AddYears(increment);
+                    return CouldAddYearsToDate(date.Year + increment) ? date.AddYears(increment) : date;
                 case CalendarDisplayMode.DecadeView:
-                    return date.AddYears(increment * 10);
+                    return CouldAddYearsToDate(date.Year + (increment * 10)) ? date.AddYears(increment * 10) : date;
                 case CalendarDisplayMode.CenturyView:
-                    return date.AddYears(increment * 100);
+                    return CouldAddYearsToDate(date.Year + (increment * 100)) ? date.AddYears(increment * 100) : date;
                 default:
-                    return date.AddMonths(increment);
+                    return date.Year == DateTime.MinValue.Year && date.Month == DateTime.MinValue.Month && increment < 0 
+                        || date.Year == DateTime.MaxValue.Year && date.Month == DateTime.MaxValue.Month && increment > 0
+                        ? date : date.AddMonths(increment);
             }
+        }
+
+        internal static bool CouldAddYearsToDate(int year)
+        {
+            return year >= DateTime.MinValue.Year && year <= DateTime.MaxValue.Year;
         }
 
         private static DateTime GetLastDateOfMonthView(DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarCenturyViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarCenturyViewModel.cs
@@ -30,7 +30,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal override DateTime GetNextDateToRender(DateTime date)
         {
-            return date.AddYears(10);
+            return CalendarMathHelper.CouldAddYearsToDate(date.Year + 10) ? date.AddYears(10) : date;
         }
 
         internal override void PrepareCalendarCell(CalendarCellModel cell, DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarDecadeViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarDecadeViewModel.cs
@@ -30,7 +30,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal override DateTime GetNextDateToRender(DateTime date)
         {
-            return date.AddYears(1);
+            return CalendarMathHelper.CouldAddYearsToDate(date.Year + 1) ? date.AddYears(1) : date;
         }
 
         internal override void PrepareCalendarCell(CalendarCellModel cell, DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarMonthViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarMonthViewModel.cs
@@ -50,12 +50,12 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
                 daysToSubtract += 7;
             }
 
-            return monthStartDate.AddDays(-daysToSubtract);
+            return monthStartDate.Date == DateTime.MinValue.Date ? monthStartDate : monthStartDate.AddDays(-daysToSubtract);
         }
 
         internal override DateTime GetNextDateToRender(DateTime dateToRender)
         {
-            return dateToRender.AddDays(1);
+            return dateToRender.Date == DateTime.MaxValue.Date ? dateToRender : dateToRender.AddDays(1);
         }
 
         internal override void PrepareCalendarCell(CalendarCellModel cell, DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarYearViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarYearViewModel.cs
@@ -30,7 +30,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal override DateTime GetNextDateToRender(DateTime date)
         {
-            return date.AddMonths(1);
+            return date.Month == DateTime.MaxValue.Month && date.Year == DateTime.MaxValue.Year ? date : date.AddMonths(1);
         }
 
         internal override void PrepareCalendarCell(CalendarCellModel cell, DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -2375,7 +2375,8 @@ namespace Telerik.UI.Xaml.Controls.Input
             if (this.AppointmentSource != null && this.IsTemplateApplied)
             {
                 DateTime startDate = GetFirstDayofMonth(this.DisplayDate, this.currentCulture.Calendar);
-                this.AppointmentSource.AllAppointments = this.AppointmentSource.FetchData(startDate, startDate.AddMonths(1));
+                this.AppointmentSource.AllAppointments = this.AppointmentSource.FetchData(startDate,
+                    startDate.Month == DateTime.MaxValue.Month && startDate.Year == DateTime.MaxValue.Year ? startDate : startDate.AddMonths(1));
             }
         }
 


### PR DESCRIPTION
…ng to set DateTime out of the Min and Max value.