### PR TITLE
Set FallbackValue for min and max for the numericeditor in the dataform. #210

### DIFF
--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/NumericEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/NumericEditor.cs
@@ -135,10 +135,12 @@ namespace Telerik.UI.Xaml.Controls.Data
 
             Binding rangeB = new Binding();
             rangeB.Path = new PropertyPath("Range.Min");
+            rangeB.FallbackValue = double.MinValue;
             this.SetBinding(NumericEditor.MinimumProperty, rangeB);
 
             rangeB = new Binding();
             rangeB.Path = new PropertyPath("Range.Max");
+            rangeB.FallbackValue = double.MaxValue;
             this.SetBinding(NumericEditor.MaximumProperty, rangeB);
         }
     }


### PR DESCRIPTION
#210  
  
Open the EditMode SDK example and change the mode to external - the NumericInput of the visualized should be able to except values larger than 100 and lower than 0.