### PR TITLE
Remove use of static for RadDataGrid columns.

### DIFF
--- a/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridBooleanColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridBooleanColumn.cs
@@ -16,10 +16,11 @@ namespace Telerik.UI.Xaml.Controls.Grid
         private const string CheckedGlyph = "\u2611";
         private const string IndeterminateGlyph = "\u25A3";
 
-        private static Style defaultCellEditorStyle;
-        private static Style defaultCellStyle;
         private static Type booleanType = typeof(bool);
         private static Type checkBoxType = typeof(CheckBox);
+
+        private Style defaultCellEditorStyle;
+        private Style defaultCellStyle;
 
         internal override Style DefaultCellContentStyle
         {

--- a/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridComboBoxColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridComboBoxColumn.cs
@@ -40,7 +40,8 @@ namespace Telerik.UI.Xaml.Controls.Grid
             DependencyProperty.Register(nameof(DisplayMemberPath), typeof(string), typeof(DataGridComboBoxColumn), new PropertyMetadata(string.Empty, OnDisplayMemberPathChanged));
 
         private static readonly Type comboBoxType = typeof(ComboBox);
-        private static Style defaultCellEditorStyle;
+
+        private Style defaultCellEditorStyle;
         private Type itemsType;
         private Func<object, object> itemPropertyGetter;
 

--- a/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridDateColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridDateColumn.cs
@@ -17,7 +17,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
         private static TypeInfo dateTypeInfo = typeof(DateTime).GetTypeInfo();
         private static Type datePickerType = typeof(RadDatePicker);
 
-        private static Style defaultCellEditorStyle;
+        private Style defaultCellEditorStyle;
 
         internal override Style DefaultCellEditorStyle
         {

--- a/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridNumericalColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridNumericalColumn.cs
@@ -13,8 +13,9 @@ namespace Telerik.UI.Xaml.Controls.Grid
     /// </summary>
     public class DataGridNumericalColumn : DataGridTextColumn
     {
-        private static Style defaultCellEditorStyle;
         private static Type numericBoxType = typeof(RadNumericBox);
+
+        private Style defaultCellEditorStyle;
 
         internal override Style DefaultCellEditorStyle
         {

--- a/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridTextColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridTextColumn.cs
@@ -20,12 +20,12 @@ namespace Telerik.UI.Xaml.Controls.Grid
             DependencyProperty.Register(nameof(CellContentFormat), typeof(string), typeof(DataGridTextColumn), new PropertyMetadata(null, OnCellContentFormatChanged));
 
         internal static Type TextBlockType = typeof(TextBlock);
-        private static Style defaultTextCellStyle;
-        private static Style defaultCellEditorStyle;
-        private static Style defaultCellFlyoutContentStyle;
 
         private static Type textBoxType = typeof(TextBox);
 
+        private Style defaultTextCellStyle;
+        private Style defaultCellEditorStyle;
+        private Style defaultCellFlyoutContentStyle;
         private string cellContentFormatCache;
 
         /// <summary>

--- a/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridTimeColumn.cs
+++ b/Controls/Grid/Grid.UWP/View/Columns/TypedColumns/DataGridTimeColumn.cs
@@ -17,7 +17,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
         private static TypeInfo dateTypeInfo = typeof(DateTime).GetTypeInfo();
         private static Type timePickerType = typeof(RadTimePicker);
 
-        private static Style defaultCellEditorStyle;
+        private Style defaultCellEditorStyle;
 
         internal override Style DefaultCellEditorStyle
         {

--- a/Controls/Grid/Grid.UWP/View/RadDataGrid.Model.cs
+++ b/Controls/Grid/Grid.UWP/View/RadDataGrid.Model.cs
@@ -15,8 +15,6 @@ namespace Telerik.UI.Xaml.Controls.Grid
 {
     public partial class RadDataGrid
     {
-        private double cellsRowHeight = 40;
-
         private GridModel model;
 
         [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes")]


### PR DESCRIPTION
RadDataGrid does not currently work under 16299 (Fall Creators Update)  when creating in a second window and therefore a second thread because the Style cashes a dispatcher that is thread specific. The fix is just to remove the static modifier so that each instance of RadDataGrid loads the styles from resources.