### PR TITLE
RadDataForm EntityProvider is now initialized immediately

### DIFF
--- a/Controls/DataControls/DataControls.UWP/DataControls.UWP.csproj
+++ b/Controls/DataControls/DataControls.UWP/DataControls.UWP.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="Common\ContainerGeneration\HexItemModelGenerator.cs" />
     <Compile Include="DataForm\View\Editors\DataFormComboBoxItem.cs" />
+    <Compile Include="DataForm\View\Editors\IEditor.cs" />
     <Compile Include="DataForm\View\Editors\SegmentedControlCustomEditor.cs" />
     <Compile Include="DataForm\View\Editors\SliderCustomEditor.cs" />
     <Compile Include="ListView\Data\ListViewDataView.cs" />

--- a/Controls/DataControls/DataControls.UWP/DataForm/Model/DataFormModel.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/Model/DataFormModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Telerik.Data.Core;
 using Telerik.UI.Xaml.Controls.Data.DataForm;
 using Telerik.UI.Xaml.Controls.Data.DataForm.View;
@@ -8,8 +10,8 @@ namespace Telerik.UI.Xaml.Controls.Data
     internal partial class DataFormModel
     {
         private Entity entity;
-
         private EntityEditorGenerator containerGenerator;
+        private Dictionary<EntityProperty, EntityPropertyControl> propertyToEditor = new Dictionary<EntityProperty, EntityPropertyControl>();
 
         internal DataFormModel(IDataFormView view)
         {
@@ -86,10 +88,14 @@ namespace Telerik.UI.Xaml.Controls.Data
                 this.CreateDefaultEntityProvider();
             }
 
-            this.entityProvider.OnItemChanged(newItem);
-            this.containerGenerator.RemoveAll();
-            this.Entity = this.entityProvider.GenerateEntity();
-            this.Entity.IsReadOnly = this.View.IsReadOnly;
+            if (this.entityProvider.Context != newItem)
+            {
+                this.entityProvider.OnItemChanged(newItem);
+                this.containerGenerator.RemoveAll();
+                this.Entity = this.entityProvider.GenerateEntity();
+                this.Entity.IsReadOnly = this.View.IsReadOnly;
+            }
+
             this.BuildEditors();
         }
 
@@ -132,30 +138,34 @@ namespace Telerik.UI.Xaml.Controls.Data
 
         private void BuildEditors()
         {
-            var properties = this.entity.Properties.OrderBy((property) => property.Index);
-
-            foreach (var entityProperty in properties)
+            if (this.View.IsTemplateApplied)
             {
-                object groupContainer = null;
+                this.propertyToEditor.Clear();
 
-                if (entityProperty.GroupKey != null)
+                var properties = this.entity.Properties.OrderBy((property) => property.Index);
+
+                foreach (var entityProperty in properties)
                 {
-                    groupContainer = this.GetOrCreateGroupContainer(entityProperty.GroupKey);
-                }
-
-                var editor = this.containerGenerator.CreateContainer(entityProperty);
-
-                if (editor != null)
-                {
-                    this.containerGenerator.PrepareContainer(editor, entityProperty);
-
-                    if (entityProperty.GroupKey == null)
+                    object groupContainer = null;
+                    if (entityProperty.GroupKey != null)
                     {
-                        this.View.AddEditor(editor);
+                        groupContainer = this.GetOrCreateGroupContainer(entityProperty.GroupKey);
                     }
-                    else
+
+                    var editor = this.containerGenerator.CreateContainer(entityProperty);
+                    if (editor != null)
                     {
-                        this.containerGenerator.AddViewToGroupContainer(groupContainer, editor);
+                        this.propertyToEditor.Add(entityProperty, editor);
+                        this.containerGenerator.PrepareContainer(editor, entityProperty);
+
+                        if (entityProperty.GroupKey == null)
+                        {
+                            this.View.AddEditor(editor);
+                        }
+                        else
+                        {
+                            this.containerGenerator.AddViewToGroupContainer(groupContainer, editor);
+                        }
                     }
                 }
             }
@@ -172,6 +182,13 @@ namespace Telerik.UI.Xaml.Controls.Data
             }
 
             return container;
+        }
+
+        internal object GetEditorCurrentValue(EntityProperty entityProperty)
+        {
+            EntityPropertyControl control;
+            this.propertyToEditor.TryGetValue(entityProperty, out control);
+            return control?.GetCurrentValue();
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/Model/IDataFormView.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/Model/IDataFormView.cs
@@ -11,6 +11,7 @@ namespace Telerik.UI.Xaml.Controls.Data
         CommandService CommandService { get; }
         ITransactionService TransactionService { get; }
 
+        bool IsTemplateApplied { get; }
         bool IsReadOnly { get; }
 
         void AddEditor(object element);

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/AutoCompleteEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/AutoCompleteEditor.cs
@@ -8,7 +8,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents an AutoCompleteEditor control.
     /// </summary>
-    public class AutoCompleteEditor : RadAutoCompleteBox, ITypeEditor
+    public class AutoCompleteEditor : RadAutoCompleteBox, ITypeEditor, IEditor
     {
         /// <summary>
         /// Identifies the <see cref="LabelIconStyle"/> dependency property. 
@@ -105,6 +105,11 @@ namespace Telerik.UI.Xaml.Controls.Data
             Binding b4 = new Binding();
             b4.Path = new PropertyPath("ValueOptions");
             this.SetBinding(AutoCompleteEditor.ItemsSourceProperty, b4);
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.Text;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/BooleanEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/BooleanEditor.cs
@@ -9,7 +9,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a BooleanEditor control.
     /// </summary>
-    public class BooleanEditor : CheckBox, ITypeEditor
+    public class BooleanEditor : CheckBox, ITypeEditor, IEditor
     {
         /// <summary>
         /// Identifies the <see cref="CheckedStateBackgroundBrush"/> dependency property. 
@@ -53,6 +53,11 @@ namespace Telerik.UI.Xaml.Controls.Data
             b3.Converter = new IsEnabledEditorConvetrer();
             b3.Path = new PropertyPath(string.Empty);
             this.SetBinding(BooleanEditor.IsEnabledProperty, b3);
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.IsChecked;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/CustomEditors/ToggleSwitchCustomEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/CustomEditors/ToggleSwitchCustomEditor.cs
@@ -9,7 +9,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a ToggleSwitchCustomEditor control.
     /// </summary>
-    public class ToggleSwitchCustomEditor : CustomEditorBase<ToggleSwitch>
+    public class ToggleSwitchCustomEditor : CustomEditorBase<ToggleSwitch>, IEditor
     {
         /// <summary>
         /// Identifies the <see cref="SelectedBackgroundBrush"/> dependency property. 
@@ -166,6 +166,11 @@ namespace Telerik.UI.Xaml.Controls.Data
                 this.switchKnobOffEllipse.Fill = this.OffStateBackground;
                 this.outerBorderRect.Stroke = this.OffStateBackground;
             }
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.EditorControl.IsOn;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/DateEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/DateEditor.cs
@@ -11,7 +11,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a DateEditor control.
     /// </summary>
-    public class DateEditor : RadDatePicker, ITypeEditor
+    public class DateEditor : RadDatePicker, ITypeEditor, IEditor
     {
         /// <summary>
         /// Identifies the <see cref="LabelIconStyle"/> dependency property. 
@@ -149,6 +149,11 @@ namespace Telerik.UI.Xaml.Controls.Data
             b3.Converter = new IsEnabledEditorConvetrer();
             b3.Path = new PropertyPath(string.Empty);
             this.SetBinding(DateEditor.IsEnabledProperty, b3);
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.Value;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/EditorGeneration/EntityEditorGenerator.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/EditorGeneration/EntityEditorGenerator.cs
@@ -28,7 +28,7 @@ namespace Telerik.UI.Xaml.Controls.Data.DataForm.View
 
         internal EditorFactory EditorFactory { get; set; }
 
-        public object CreateContainer(EntityProperty entityProperty)
+        public EntityPropertyControl CreateContainer(EntityProperty entityProperty)
         {
             var element = this.EditorFactory.CreateEditor(entityProperty);
 

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/EntityPropertyControl.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/EntityPropertyControl.cs
@@ -1,4 +1,5 @@
-﻿using Telerik.Data.Core;
+﻿using System;
+using Telerik.Data.Core;
 using Telerik.UI.Xaml.Controls.Data.DataForm;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -218,6 +219,16 @@ namespace Telerik.UI.Xaml.Controls.Data
             {
                 this.container.Children.Add(view);
             }
+        }
+
+        internal object GetCurrentValue()
+        {
+            if (this.View is IEditor editor)
+            {
+                return editor.GetCurrentValue();
+            }
+
+            return null;
         }
 
         /// <inheritdoc/>

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/EnumEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/EnumEditor.cs
@@ -8,7 +8,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents an EnumEditor control.
     /// </summary>
-    public class EnumEditor : ComboBox, ITypeEditor
+    public class EnumEditor : ComboBox, ITypeEditor, IEditor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumEditor"/> class.
@@ -55,6 +55,11 @@ namespace Telerik.UI.Xaml.Controls.Data
         protected override DependencyObject GetContainerForItemOverride()
         {
             return new DataFormComboBoxItem();
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.SelectedIndex;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/IEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/IEditor.cs
@@ -1,0 +1,7 @@
+﻿namespace Telerik.UI.Xaml.Controls.Data
+{
+    interface IEditor
+    {
+        object GetCurrentValue();
+    }
+}

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/ListEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/ListEditor.cs
@@ -8,7 +8,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a ListEditor control.
     /// </summary>
-    public class ListEditor : ComboBox, ITypeEditor
+    public class ListEditor : ComboBox, ITypeEditor, IEditor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ListEditor"/> class.
@@ -50,6 +50,11 @@ namespace Telerik.UI.Xaml.Controls.Data
         protected override DependencyObject GetContainerForItemOverride()
         {
             return new DataFormComboBoxItem();
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.SelectedItem;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/NumericEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/NumericEditor.cs
@@ -9,7 +9,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a NumericEditor control.
     /// </summary>
-    public class NumericEditor : RadNumericBox, ITypeEditor
+    public class NumericEditor : RadNumericBox, ITypeEditor, IEditor
     {
         /// <summary>
         /// Identifies the <see cref="ErrorIconStyle"/> dependency property. 
@@ -142,6 +142,11 @@ namespace Telerik.UI.Xaml.Controls.Data
             rangeB.Path = new PropertyPath("Range.Max");
             rangeB.FallbackValue = double.MaxValue;
             this.SetBinding(NumericEditor.MaximumProperty, rangeB);
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.Value;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/SegmentedControlCustomEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/SegmentedControlCustomEditor.cs
@@ -9,7 +9,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a SegmentedCustomEditor control.
     /// </summary>
-    public class SegmentedCustomEditor : RadSegmentedControl, ITypeEditor
+    public class SegmentedCustomEditor : RadSegmentedControl, ITypeEditor, IEditor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SegmentedCustomEditor"/> class.
@@ -36,6 +36,11 @@ namespace Telerik.UI.Xaml.Controls.Data
             b3.Converter = new IsEnabledEditorConvetrer();
             b3.Path = new PropertyPath(string.Empty);
             this.SetBinding(SegmentedCustomEditor.IsEnabledProperty, b3);
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.SelectedItem;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/SliderCustomEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/SliderCustomEditor.cs
@@ -10,7 +10,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a SliderCustomEditor control.
     /// </summary>
-    public class SliderCustomEditor : Slider, ITypeEditor
+    public class SliderCustomEditor : Slider, ITypeEditor, IEditor
     {
         /// <summary>
         /// Identifies the <see cref="ThumbBackground"/> dependency property. 
@@ -66,6 +66,11 @@ namespace Telerik.UI.Xaml.Controls.Data
             Binding b5 = new Binding() { Mode = BindingMode.TwoWay };
             b5.Path = new PropertyPath("PropertyValue");
             this.SetBinding(SliderCustomEditor.ValueProperty, b5);
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.Value;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/StringEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/StringEditor.cs
@@ -8,7 +8,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a StringEditor control.
     /// </summary>
-    public class StringEditor : TextBox, ITypeEditor
+    public class StringEditor : TextBox, ITypeEditor, IEditor
     {
         /// <summary>
         /// Identifies the <see cref="LabelIconStyle"/> dependency property. 
@@ -101,6 +101,11 @@ namespace Telerik.UI.Xaml.Controls.Data
             b3.Converter = new IsEnabledEditorConvetrer();
             b3.Path = new PropertyPath(string.Empty);
             this.SetBinding(StringEditor.IsEnabledProperty, b3);
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.Text;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/TimeEditor.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/Editors/TimeEditor.cs
@@ -11,7 +11,7 @@ namespace Telerik.UI.Xaml.Controls.Data
     /// <summary>
     /// Represents a TimeEditor control.
     /// </summary>
-    public class TimeEditor : RadTimePicker, ITypeEditor
+    public class TimeEditor : RadTimePicker, ITypeEditor, IEditor
     {
         /// <summary>
         /// Identifies the <see cref="IconDisplayMode"/> dependency property. 
@@ -149,6 +149,11 @@ namespace Telerik.UI.Xaml.Controls.Data
             b3.Converter = new IsEnabledEditorConvetrer();
             b3.Path = new PropertyPath(string.Empty);
             this.SetBinding(TimeEditor.IsEnabledProperty, b3);
+        }
+
+        object IEditor.GetCurrentValue()
+        {
+            return this.Value;
         }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/DataForm/View/RadDataForm.cs
+++ b/Controls/DataControls/DataControls.UWP/DataForm/View/RadDataForm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using Telerik.Data.Core;
 using Telerik.UI.Automation.Peers;
@@ -332,6 +333,14 @@ namespace Telerik.UI.Xaml.Controls.Data
             this.Model.RefreshLayout();
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public object GetEditorValueForProperty(EntityProperty entityProperty)
+        {
+            return this.Model.GetEditorCurrentValue(entityProperty);
+        }
+
+        bool IDataFormView.IsTemplateApplied { get => this.IsTemplateApplied; }
+
         void IDataFormView.PrepareEditor(object editor, object groupVisual)
         {
             var editorElement = editor as EntityPropertyControl;
@@ -478,10 +487,7 @@ namespace Telerik.UI.Xaml.Controls.Data
         private static void OnItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             RadDataForm form = d as RadDataForm;
-            if (form.IsTemplateApplied)
-            {
-                form.Model.OnItemChanged(e.NewValue);
-            }
+            form.Model.OnItemChanged(e.NewValue);
         }
 
         private static void OnEntityProviderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
 when Item is set. Editors are build when template is applied.
Implement method to get editor current value for testing purposes.