### PR TITLE
Prevent handling of the ListViewItem's KeyDown when the sender is not…

### DIFF
--- a/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.cs
@@ -517,6 +517,11 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView
         {
             base.OnKeyDown(e);
 
+            if (e.OriginalSource != this)
+            {
+                return;
+            }
+
             bool success = false;
             this.ListView.currentLogicalIndex = this.logicalIndex;
 


### PR DESCRIPTION
… the item itself.