### PR TITLE
Atanasov/fetch calendar appointments

### DIFF
--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarCenturyViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarCenturyViewModel.cs
@@ -25,7 +25,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal override DateTime GetFirstDateToRender(DateTime date)
         {
-            return CalendarMathHelper.GetFirstDateOfCentury(date);
+            return this.Calendar.GetFirstDateToRenderForDisplayMode(date, CalendarDisplayMode.CenturyView);
         }
 
         internal override DateTime GetNextDateToRender(DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarDecadeViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarDecadeViewModel.cs
@@ -25,7 +25,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal override DateTime GetFirstDateToRender(DateTime date)
         {
-            return CalendarMathHelper.GetFirstDateOfDecade(date);
+            return this.Calendar.GetFirstDateToRenderForDisplayMode(date, CalendarDisplayMode.DecadeView);
         }
 
         internal override DateTime GetNextDateToRender(DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarModel.cs
@@ -447,7 +447,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
                 DateTime monthStartDate = CalendarMathHelper.GetFirstDateOfMonth(date);
 
-                int daysToSubtract = (int) monthStartDate.DayOfWeek - (int) firstDayOfWeekToUse;
+                int daysToSubtract = (int)monthStartDate.DayOfWeek - (int)firstDayOfWeekToUse;
                 if (daysToSubtract <= 0)
                 {
                     daysToSubtract += 7;
@@ -465,7 +465,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
             }
             else if (displayMode == CalendarDisplayMode.CenturyView)
             {
-                firstDateToRender =  CalendarMathHelper.GetFirstDateOfCentury(date);
+                firstDateToRender = CalendarMathHelper.GetFirstDateOfCentury(date);
             }
 
             return firstDateToRender;

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarModel.cs
@@ -418,6 +418,59 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
             return this.View.MeasureContent(owner, content);
         }
 
+        internal DateTime GetFirstDateToRenderForDisplayMode(DateTime date, CalendarDisplayMode displayMode)
+        {
+            DateTime firstDateToRender = date;
+
+            if (displayMode == CalendarDisplayMode.MultiDayView)
+            {
+                DayOfWeek firstDayOfWeek = this.GetFirstDayOfWeek();
+                DateTime firstDateOfCurrentWeek = CalendarMathHelper.GetFirstDayOfCurrentWeek(date, firstDayOfWeek);
+
+                if (!(firstDateOfCurrentWeek.Date <= date.Date && firstDateOfCurrentWeek.AddDays(7).Date >= date.Date))
+                {
+                    firstDateToRender = firstDateOfCurrentWeek;
+                }
+
+                if (!this.multiDayViewSettings.WeekendsVisible)
+                {
+                    firstDateToRender = CalendarMathHelper.AddBusinessDays(date, -this.multiDayViewSettings.VisibleDays);
+                }
+                else
+                {
+                    firstDateToRender = date.AddDays(-this.multiDayViewSettings.VisibleDays);
+                }
+            }
+            else if (displayMode == CalendarDisplayMode.MonthView)
+            {
+                DayOfWeek firstDayOfWeekToUse = this.GetFirstDayOfWeek();
+
+                DateTime monthStartDate = CalendarMathHelper.GetFirstDateOfMonth(date);
+
+                int daysToSubtract = (int) monthStartDate.DayOfWeek - (int) firstDayOfWeekToUse;
+                if (daysToSubtract <= 0)
+                {
+                    daysToSubtract += 7;
+                }
+
+                firstDateToRender = monthStartDate.Date == DateTime.MinValue.Date ? monthStartDate : monthStartDate.AddDays(-daysToSubtract);
+            }
+            else if (displayMode == CalendarDisplayMode.YearView)
+            {
+                firstDateToRender = CalendarMathHelper.GetFirstDateOfYear(date);
+            }
+            else if (displayMode == CalendarDisplayMode.DecadeView)
+            {
+                firstDateToRender = CalendarMathHelper.GetFirstDateOfDecade(date);
+            }
+            else if (displayMode == CalendarDisplayMode.CenturyView)
+            {
+                firstDateToRender =  CalendarMathHelper.GetFirstDateOfCentury(date);
+            }
+
+            return firstDateToRender;
+        }
+
         private void UpdateCurrentView()
         {
             switch (this.DisplayMode)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarMonthViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarMonthViewModel.cs
@@ -41,17 +41,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal override DateTime GetFirstDateToRender(DateTime date)
         {
-            DayOfWeek firstDayOfWeekToUse = this.Calendar.GetFirstDayOfWeek();
-
-            DateTime monthStartDate = CalendarMathHelper.GetFirstDateOfMonth(date);
-
-            int daysToSubtract = (int)monthStartDate.DayOfWeek - (int)firstDayOfWeekToUse;
-            if (daysToSubtract <= 0)
-            {
-                daysToSubtract += 7;
-            }
-
-            return monthStartDate.Date == DateTime.MinValue.Date ? monthStartDate : monthStartDate.AddDays(-daysToSubtract);
+            return this.Calendar.GetFirstDateToRenderForDisplayMode(date, CalendarDisplayMode.MonthView);
         }
 
         internal override DateTime GetNextDateToRender(DateTime dateToRender)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
@@ -66,24 +66,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal override DateTime GetFirstDateToRender(DateTime date)
         {
-            DayOfWeek firstDayOfWeek = this.Calendar.GetFirstDayOfWeek();
-            DateTime firstDateOfCurrentWeek = CalendarMathHelper.GetFirstDayOfCurrentWeek(date, firstDayOfWeek);
-
-            if (!(firstDateOfCurrentWeek.Date <= date.Date && firstDateOfCurrentWeek.AddDays(7).Date >= date.Date))
-            {
-                date = firstDateOfCurrentWeek;
-            }
-
-            if (!this.Calendar.multiDayViewSettings.WeekendsVisible)
-            {
-                date = CalendarMathHelper.AddBusinessDays(date, -this.BufferItemsCount);
-            }
-            else
-            {
-                date = date.AddDays(-this.BufferItemsCount);
-            }
-
-            return date;
+            return this.Calendar.GetFirstDateToRenderForDisplayMode(date, CalendarDisplayMode.MultiDayView);
         }
 
         internal override DateTime GetNextDateToRender(DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarYearViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarYearViewModel.cs
@@ -25,7 +25,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal override DateTime GetFirstDateToRender(DateTime date)
         {
-            return CalendarMathHelper.GetFirstDateOfYear(date);
+            return this.Calendar.GetFirstDateToRenderForDisplayMode(date, CalendarDisplayMode.YearView);
         }
 
         internal override DateTime GetNextDateToRender(DateTime date)

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/MultiDayViewSettings.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/MultiDayViewSettings.cs
@@ -163,7 +163,6 @@ namespace Telerik.UI.Xaml.Controls.Input
 
         internal const string DefaultAllDayText = "All-day";
         internal RadCalendar owner;
-        internal MultiDayViewUpdateFlag updateFlag;
         internal DispatcherTimer timer;
 
         internal StyleSelector defaultSpecialSlotStyleSelector;

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -2205,7 +2205,11 @@ namespace Telerik.UI.Xaml.Controls.Input
             if (this.MultiDayViewSettings != null && this.displayModeCache == CalendarDisplayMode.MultiDayView)
             {
                 this.MultiDayViewSettings.SetDefaultStyleValues();
-                this.MultiDayViewSettings.timer.Start();
+
+                if (this.MultiDayViewSettings.ShowCurrentTimeIndicator)
+                {
+                    this.MultiDayViewSettings.timer.Start();
+                }
             }
 
             if (this.navigationPanel != null)

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -3073,10 +3073,23 @@ namespace Telerik.UI.Xaml.Controls.Input
 
         private void FetchNewAppointments()
         {
-            if (this.AppointmentSource != null && this.IsTemplateApplied)
+            if (this.AppointmentSource != null)
             {
-                DateTime startDate = GetFirstDayofMonth(this.DisplayDate, this.currentCulture.Calendar);
-                ObservableCollection<IAppointment> fetchedAppointments = this.AppointmentSource.FetchData(startDate, startDate.Month == DateTime.MaxValue.Month && startDate.Year == DateTime.MaxValue.Year ? startDate : startDate.AddMonths(1));
+                var rowCount = this.model.RowCount;
+                int columnCount;
+                if (this.DisplayMode == CalendarDisplayMode.MultiDayView)
+                {
+                    columnCount = 3 * this.MultiDayViewSettings.VisibleDays;
+                }
+                else
+                {
+                    columnCount = this.model.ColumnCount;
+                }
+
+                DateTime startDate = this.model.GetFirstDateToRenderForDisplayMode(this.DisplayDate, this.DisplayMode);
+                DateTime endDate = startDate.AddDays(rowCount * columnCount);
+
+                ObservableCollection<IAppointment> fetchedAppointments = this.AppointmentSource.FetchData(startDate, startDate.Month == DateTime.MaxValue.Month && startDate.Year == DateTime.MaxValue.Year ? startDate : endDate);
                 this.AppointmentSource.AllAppointments.Clear();
                 foreach (IAppointment app in fetchedAppointments)
                 {

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -2463,7 +2463,12 @@ namespace Telerik.UI.Xaml.Controls.Input
 
             DateTime oldDisplayDate = (DateTime)args.OldValue;
 
-            if (calendar.displayModeCache != CalendarDisplayMode.MultiDayView
+            if (calendar.displayModeCache == CalendarDisplayMode.MultiDayView)
+            {
+                calendar.FetchNewAppointments();
+                calendar.model.multiDayViewModel.updateFlag = MultiDayViewUpdateFlag.All;
+            }
+            else if (calendar.displayModeCache == CalendarDisplayMode.MonthView
                 && (oldDisplayDate.Year != newDisplayDate.Year || oldDisplayDate.Month != newDisplayDate.Month))
             {
                 calendar.FetchNewAppointments();
@@ -2528,6 +2533,11 @@ namespace Telerik.UI.Xaml.Controls.Input
             if (calendarPeer != null)
             {
                 calendarPeer.ClearCache();
+            }
+
+            if (calendar.displayModeCache == CalendarDisplayMode.MonthView || calendar.displayModeCache == CalendarDisplayMode.MultiDayView)
+            {
+                calendar.FetchNewAppointments();
             }
         }
 

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -2538,6 +2538,7 @@ namespace Telerik.UI.Xaml.Controls.Input
             if (calendar.displayModeCache == CalendarDisplayMode.MonthView || calendar.displayModeCache == CalendarDisplayMode.MultiDayView)
             {
                 calendar.FetchNewAppointments();
+                calendar.model.multiDayViewModel.updateFlag = MultiDayViewUpdateFlag.All;
             }
         }
 


### PR DESCRIPTION
- Fix calendar appointments for next and previous month are not show when in Month display mode.

- Fix AppointmentSource.FetchData is not called when changing the display mode.

- Fix AppointmentSource.FetchData is not called for MultiDayView when changing the display date.

- Fix MultiDayView CurrentTimeIndicator is updated every second, even if the CurrentTimeIndicator visibility is set to false.
