### PR TITLE
Fix reorder in ListView with groups not handled correctly in all cases

### DIFF
--- a/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.IDragDropElement.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.IDragDropElement.cs
@@ -267,28 +267,28 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView
                 this.FinalizeReorder(context);
 
                 var isExecuted = false;
-                var destinationItem = default(RadListViewItem);
-                var placement = default(ItemReorderPlacement);
+                RadListViewItem destinationItem = null;
+                ItemReorderPlacement placement = 0;
 
                 if (data.InitialSourceIndex < data.CurrentSourceReorderIndex)
                 {
-                    destinationItem = this.GetDestinationItem(data.CurrentSourceReorderIndex - 1);
+                    destinationItem = this.reorderCoordinator.Host.ElementAt(data.CurrentSourceReorderIndex - 1) as RadListViewItem;
                     placement = ItemReorderPlacement.After;
 
                     if (destinationItem == null)
                     {
-                        destinationItem = this.GetDestinationItem(data.CurrentSourceReorderIndex + 1);
+                        destinationItem = this.reorderCoordinator.Host.ElementAt(data.CurrentSourceReorderIndex + 1) as RadListViewItem;
                         placement = ItemReorderPlacement.Before;
                     }
                 }
                 else if (data.InitialSourceIndex > data.CurrentSourceReorderIndex)
                 {
-                    destinationItem = this.GetDestinationItem(data.CurrentSourceReorderIndex + 1);
+                    destinationItem = this.reorderCoordinator.Host.ElementAt(data.CurrentSourceReorderIndex + 1) as RadListViewItem;
                     placement = ItemReorderPlacement.Before;
 
                     if (destinationItem == null)
                     {
-                        destinationItem = this.GetDestinationItem(data.CurrentSourceReorderIndex - 1);
+                        destinationItem = this.reorderCoordinator.Host.ElementAt(data.CurrentSourceReorderIndex - 1) as RadListViewItem;
                         placement = ItemReorderPlacement.After;
                     }
                 }

--- a/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.IDragDropElement.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.IDragDropElement.cs
@@ -267,11 +267,36 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView
                 this.FinalizeReorder(context);
 
                 var isExecuted = false;
+                var destinationItem = default(RadListViewItem);
+                var placement = default(ItemReorderPlacement);
 
-                if (data.InitialSourceIndex != data.CurrentSourceReorderIndex)
+                if (data.InitialSourceIndex < data.CurrentSourceReorderIndex)
+                {
+                    destinationItem = this.GetDestinationItem(data.CurrentSourceReorderIndex - 1);
+                    placement = ItemReorderPlacement.After;
+
+                    if (destinationItem == null)
+                    {
+                        destinationItem = this.GetDestinationItem(data.CurrentSourceReorderIndex + 1);
+                        placement = ItemReorderPlacement.Before;
+                    }
+                }
+                else if (data.InitialSourceIndex > data.CurrentSourceReorderIndex)
+                {
+                    destinationItem = this.GetDestinationItem(data.CurrentSourceReorderIndex + 1);
+                    placement = ItemReorderPlacement.Before;
+
+                    if (destinationItem == null)
+                    {
+                        destinationItem = this.GetDestinationItem(data.CurrentSourceReorderIndex - 1);
+                        placement = ItemReorderPlacement.After;
+                    }
+                }
+
+                if (destinationItem != null)
                 {
                     var dataItem = data.Data;
-                    var destinationDataItem = this.GetDestinationDataItem(data.CurrentSourceReorderIndex);
+                    var destinationDataItem = destinationItem.DataContext;
 
                     IDataGroup dataGroup = null;
                     IDataGroup destinationDataGroup = null;
@@ -280,17 +305,6 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView
                     {
                         dataGroup = this.listView.Model.FindItemParentGroup(dataItem);
                         destinationDataGroup = this.listView.Model.FindItemParentGroup(destinationDataItem);
-                    }
-
-                    ItemReorderPlacement placement;
-
-                    if (data.InitialSourceIndex < data.CurrentSourceReorderIndex)
-                    {
-                        placement = ItemReorderPlacement.After;
-                    }
-                    else
-                    {
-                        placement = ItemReorderPlacement.Before;
                     }
 
                     var commandContext = new ItemReorderCompleteContext(dataItem, dataGroup, destinationDataItem, destinationDataGroup, placement);

--- a/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.cs
@@ -831,10 +831,5 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView
 
             return canReorderColumn && (draggingFromStart || draggingFromEnd);
         }
-
-        private RadListViewItem GetDestinationItem(int index)
-        {
-            return this.reorderCoordinator.Host.ElementAt(index) as RadListViewItem;
-        }
     }
 }

--- a/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.cs
+++ b/Controls/DataControls/DataControls.UWP/ListView/View/Controls/RadListViewItem.cs
@@ -832,23 +832,9 @@ namespace Telerik.UI.Xaml.Controls.Data.ListView
             return canReorderColumn && (draggingFromStart || draggingFromEnd);
         }
 
-        private object GetDestinationDataItem(int index)
+        private RadListViewItem GetDestinationItem(int index)
         {
-            int actualIndex = index;
-            if (this.listView.GroupDescriptors.Count == 0)
-            {
-                actualIndex = this.listView.Model.layoutController.strategy.GetElementFlatIndex(actualIndex);
-            }
-
-            var info = this.listView.Model.FindDataItemFromIndex(actualIndex);
-
-            object item = null;
-            if (info.HasValue)
-            {
-                item = info.Value.Item;
-            }
-
-            return item;
+            return this.reorderCoordinator.Host.ElementAt(index) as RadListViewItem;
         }
     }
 }


### PR DESCRIPTION
- Fixes reordering of an item when there are collapsed groups
- Fixes reordering of an item to the first position of a group
- Fixes reordering of an item to the last position of a group