### PR TITLE
Check for static properties and if any skip them in order to prevent …

### DIFF
--- a/Controls/Data.UWP/Data/Engine/DataSouceView/CollectionViewDataSourceView.cs
+++ b/Controls/Data.UWP/Data/Engine/DataSouceView/CollectionViewDataSourceView.cs
@@ -309,7 +309,7 @@ namespace Telerik.Data.Core
             }
 
             Type itemType = item.GetType();
-            IEnumerable<PropertyInfo> properties = itemType.GetRuntimeProperties().Where(a => a.GetMethod != null && a.GetMethod.IsPublic && !a.GetIndexParameters().Any());
+            IEnumerable<PropertyInfo> properties = itemType.GetRuntimeProperties().Where(a => a.GetMethod != null && a.GetMethod.IsPublic && !a.GetIndexParameters().Any() && !a.GetMethod.IsStatic);
 
             object tempItem = item;
             foreach (PropertyInfo info in properties)

--- a/Controls/Data.UWP/Data/Engine/DataSouceView/EnumerableDataSourceView.cs
+++ b/Controls/Data.UWP/Data/Engine/DataSouceView/EnumerableDataSourceView.cs
@@ -229,7 +229,7 @@ namespace Telerik.Data.Core
             }
 
             Type itemType = item.GetType();
-            IEnumerable<PropertyInfo> properties = itemType.GetRuntimeProperties().Where(a => a.GetMethod != null && a.GetMethod.IsPublic && !a.GetIndexParameters().Any());
+            IEnumerable<PropertyInfo> properties = itemType.GetRuntimeProperties().Where(a => a.GetMethod != null && a.GetMethod.IsPublic && !a.GetIndexParameters().Any() && !a.GetMethod.IsStatic);
 
             object tempItem = item;
             foreach (PropertyInfo info in properties)

--- a/Controls/Data.UWP/Data/Engine/Fields/Providers/EnumerableFieldDescriptionsInfoProvider.cs
+++ b/Controls/Data.UWP/Data/Engine/Fields/Providers/EnumerableFieldDescriptionsInfoProvider.cs
@@ -90,7 +90,7 @@ namespace Telerik.Data.Core.Fields
                     }
                 }
 
-                var props = currentType.GetRuntimeProperties().Where(pi => pi.GetMethod != null && !pi.GetIndexParameters().Any() && pi.GetMethod.IsPublic && pi.GetCustomAttribute<SkipAutoGenerateAttribute>() == null);
+                var props = currentType.GetRuntimeProperties().Where(pi => pi.GetMethod != null && !pi.GetIndexParameters().Any() && pi.GetMethod.IsPublic&& !pi.GetMethod.IsStatic && pi.GetCustomAttribute<SkipAutoGenerateAttribute>() == null);
                 foreach (var propertyInfo in props)
                 {
                     var propertyAccess = BindingExpressionHelper.CreateGetValueFunc(currentType, propertyInfo.Name);

--- a/Controls/Data.UWP/Data/Engine/Fields/Providers/EnumerableFieldDescriptionsInfoProvider.cs
+++ b/Controls/Data.UWP/Data/Engine/Fields/Providers/EnumerableFieldDescriptionsInfoProvider.cs
@@ -90,7 +90,7 @@ namespace Telerik.Data.Core.Fields
                     }
                 }
 
-                var props = currentType.GetRuntimeProperties().Where(pi => pi.GetMethod != null && !pi.GetIndexParameters().Any() && pi.GetMethod.IsPublic&& !pi.GetMethod.IsStatic && pi.GetCustomAttribute<SkipAutoGenerateAttribute>() == null);
+                var props = currentType.GetRuntimeProperties().Where(pi => pi.GetMethod != null && !pi.GetIndexParameters().Any() && pi.GetMethod.IsPublic && !pi.GetMethod.IsStatic && pi.GetCustomAttribute<SkipAutoGenerateAttribute>() == null);
                 foreach (var propertyInfo in props)
                 {
                     var propertyAccess = BindingExpressionHelper.CreateGetValueFunc(currentType, propertyInfo.Name);


### PR DESCRIPTION
…exception thrown when expression is built.