### PR TITLE
Added ScrollTimeRuler method

### DIFF
--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
@@ -26,11 +26,10 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         internal double timeRulerWidth;
         internal int allDayAreaRowCount;
         internal MultiDayViewUpdateFlag updateFlag;
+        internal double halfTextHeight;
 
         private const int DefaultSpecificColumnCount = 6;
         private static double DefaultCurrentTimeIndicatorHeight = 2d;
-
-        private double halfTextHeight;
 
         public override int RowCount
         {

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
@@ -556,17 +556,11 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
             double gridLineThickness = this.Calendar.GridLinesThickness;
             int gridLineHalfThickness = (int)(gridLineThickness / 2);
 
-            if ((this.Calendar.GridLinesVisibility & GridLinesVisibility.Horizontal) == GridLinesVisibility.Horizontal)
-            {
-                this.horizontalTopHeaderRulerGridLine.Arrange(new RadRect(this.layoutSlot.X, rect.Y, this.layoutSlot.Width, gridLineThickness));
-                this.horizontalUpperAllDayAreaRulerGridLine.Arrange(new RadRect(this.layoutSlot.X, rect.Y + cellHeight, this.layoutSlot.Width, gridLineThickness));
-                this.horizontalLowerAllDayAreaRulerGridLine.Arrange(new RadRect(this.layoutSlot.X, rect.Y + cellHeight + this.totalAllDayAreaHeight + gridLineThickness / 2, this.layoutSlot.Width, 0));
-            }
+            this.horizontalTopHeaderRulerGridLine.Arrange(new RadRect(this.layoutSlot.X, rect.Y, this.layoutSlot.Width, gridLineThickness));
+            this.horizontalUpperAllDayAreaRulerGridLine.Arrange(new RadRect(this.layoutSlot.X, rect.Y + cellHeight, this.layoutSlot.Width, gridLineThickness));
+            this.horizontalLowerAllDayAreaRulerGridLine.Arrange(new RadRect(this.layoutSlot.X, rect.Y + cellHeight + this.totalAllDayAreaHeight + gridLineThickness / 2, this.layoutSlot.Width, 0));
 
-            if ((this.Calendar.GridLinesVisibility & GridLinesVisibility.Vertical) == GridLinesVisibility.Vertical)
-            {
-                this.verticalRulerGridLine.Arrange(new RadRect(rect.X, rect.Y, gridLineThickness, rect.Height));
-            }
+            this.verticalRulerGridLine.Arrange(new RadRect(rect.X, rect.Y, gridLineThickness, rect.Height));
         }
 
         private void EnsureTimeRulerItems()

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -326,6 +326,7 @@ namespace Telerik.UI.Xaml.Controls.Input
         internal List<CalendarDateRange> unattachedSelectedRanges;
         internal CalendarViewHost calendarViewHost;
         internal IAppointment pendingScrollToAppointment;
+        internal Action pendingScrollTimeRuler;
         internal CalendarCellStyle defaultDayNameCellStyle;
 
         private const string DefaultMonthViewHeaderFormatString = "{0:MMMM yyyy}";
@@ -1659,7 +1660,7 @@ namespace Telerik.UI.Xaml.Controls.Input
             }
             set
             {
-               this.SetValue(HeaderVisibilityProperty, value);
+                this.SetValue(HeaderVisibilityProperty, value);
             }
         }
 
@@ -1828,6 +1829,22 @@ namespace Telerik.UI.Xaml.Controls.Input
             else
             {
                 this.pendingScrollToAppointment = appointment;
+            }
+        }
+
+        /// <summary>
+        /// Scrolls the TimeRuler to the specified time.
+        /// </summary>
+        /// <param name="time">Time that should be scrolled into view.</param>
+        public void ScrollTimeRuler(TimeSpan time)
+        {
+            if (this.timeRulerLayer != null && this.timeRulerLayer.Owner != null)
+            {
+                this.timeRulerLayer.ScrollTimeRuler(time);
+            }
+            else
+            {
+                this.pendingScrollTimeRuler = () => { this.timeRulerLayer.ScrollTimeRuler(time); };
             }
         }
 
@@ -3255,7 +3272,7 @@ namespace Telerik.UI.Xaml.Controls.Input
             this.headerContentLayer.UpdateUI();
             this.contentLayer.UpdateUI();
 
-            if (this.displayModeCache == CalendarDisplayMode.MultiDayView 
+            if (this.displayModeCache == CalendarDisplayMode.MultiDayView
                 && this.allDayAreaLayer.Owner != null && this.timeRulerLayer.Owner != null)
             {
                 this.allDayAreaLayer.UpdateAllDayAreaUI();
@@ -3309,7 +3326,7 @@ namespace Telerik.UI.Xaml.Controls.Input
             // NOTE: DisplayDateStart / End property change will trigger cell state evaluation but will not invalidate the models
             // so we need to clear the flag explicitly in case it was set for a certain cell and does not need to be set given the current conditions.
             context.IsBlackout = this.IsBlackoutDate(cell);
-            
+
             if (cell.Date == DateTime.Today && this.IsTodayHighlighted && (this.DisplayMode == CalendarDisplayMode.MonthView || this.DisplayMode == CalendarDisplayMode.MultiDayView))
             {
                 this.highlightedCellCache = cell;
@@ -3461,8 +3478,8 @@ namespace Telerik.UI.Xaml.Controls.Input
             {
                 if (this.DayNameCellStyleSelector != null)
                 {
-                    var defaultDayNameCellStyle = this.DayNameCellStyle != null 
-                        ? this.DayNameCellStyle.ContentStyle 
+                    var defaultDayNameCellStyle = this.DayNameCellStyle != null
+                        ? this.DayNameCellStyle.ContentStyle
                         : this.defaultDayNameCellStyle.ContentStyle;
                     var userDefinedDayNameCellStyle = this.DayNameCellStyleSelector.SelectStyle(cell.Label, this);
 

--- a/SDKExamples.UWP/Examples/Calendar/MultiDayView.xaml
+++ b/SDKExamples.UWP/Examples/Calendar/MultiDayView.xaml
@@ -66,6 +66,8 @@
                         <Button Content="Change week visibility" Click="Button_Click"/>
                         <Button Content="Scroll to random appointment" Click="ScrollToAppointmentBtnClicked"/>
                         <TextBlock x:Name="scrollToTb" Visibility="Collapsed"/>
+                        <TextBlock Text="Time to scroll"/>
+                        <input:RadTimePicker ValueChanged="OnRadTimePickerValueChanged"/>
                         <TextBlock Text="Week step"/>
                         <ComboBox ItemsSource="{Binding DisplayDays}" SelectedItem="{Binding SelectedVisibleDays, Mode=TwoWay}"/>
                         <TextBlock Text="Tick length"/>

--- a/SDKExamples.UWP/Examples/Calendar/MultiDayView.xaml.cs
+++ b/SDKExamples.UWP/Examples/Calendar/MultiDayView.xaml.cs
@@ -2,7 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Telerik.Core;
-using Telerik.UI.Xaml.Controls.Input.Calendar;
+using Telerik.UI.Xaml.Controls.Input;
 using Telerik.UI.Xaml.Controls.Primitives;
 using Windows.UI;
 using Windows.UI.Xaml.Data;
@@ -66,6 +66,17 @@ namespace SDKExamples.UWP.Calendar
             else
             {
                 this.calendar.DayNamesVisibility = Windows.UI.Xaml.Visibility.Collapsed;
+            }
+        }
+
+        private void OnRadTimePickerValueChanged(object sender, EventArgs e)
+        {
+            var timePicker = (RadTimePicker)sender;
+            var selectedTime = timePicker.Value;
+            if (selectedTime.HasValue)
+            {
+                var currentTime = selectedTime.Value.TimeOfDay;
+                this.calendar.ScrollTimeRuler(new TimeSpan(currentTime.Hours, currentTime.Minutes, 0));
             }
         }
     }


### PR DESCRIPTION
Using the ScrollTimeRuler you can scroll to a specific time of the time ruler. The scrolling API of the MultiDayView is improved by adding such a method. It is addition to the ScrollToAppointment functionality.