### PR TITLE
Improve the Special slots of the MultiDayView.

### DIFF
--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
@@ -12,7 +12,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         internal ElementCollection<CalendarGridLine> timerRulerLines;
         internal List<CalendarAppointmentInfo> appointmentInfos;
         internal List<CalendarAppointmentInfo> allDayAppointmentInfos;
-        internal List<KeyValuePair<Slot,Slot>> specialSlots;
+        internal List<KeyValuePair<Slot, Slot>> specialSlots;
 
         internal CalendarGridLine horizontalLowerAllDayAreaRulerGridLine;
         internal CalendarGridLine horizontalUpperAllDayAreaRulerGridLine;
@@ -324,7 +324,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         {
             if (this.specialSlots == null)
             {
-                this.specialSlots = new List<KeyValuePair<Slot,Slot>>();
+                this.specialSlots = new List<KeyValuePair<Slot, Slot>>();
             }
             else
             {

--- a/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/CalendarMultiDayViewModel.cs
@@ -12,6 +12,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         internal ElementCollection<CalendarGridLine> timerRulerLines;
         internal List<CalendarAppointmentInfo> appointmentInfos;
         internal List<CalendarAppointmentInfo> allDayAppointmentInfos;
+        internal List<KeyValuePair<Slot,Slot>> specialSlots;
 
         internal CalendarGridLine horizontalLowerAllDayAreaRulerGridLine;
         internal CalendarGridLine horizontalUpperAllDayAreaRulerGridLine;
@@ -321,15 +322,22 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         private void EnsureSlots()
         {
+            if (this.specialSlots == null)
+            {
+                this.specialSlots = new List<KeyValuePair<Slot,Slot>>();
+            }
+            else
+            {
+                foreach (var slot in this.specialSlots)
+                {
+                    slot.Value.layoutSlot = RadRect.Empty;
+                }
+            }
+
             MultiDayViewSettings settings = this.Calendar.multiDayViewSettings;
             IEnumerable<Slot> slots = settings.SpecialSlotsSource;
             if (slots != null && slots.Count() > 0)
             {
-                foreach (Slot slot in slots)
-                {
-                    slot.layoutSlot = RadRect.Empty;
-                }
-
                 foreach (var calendarCell in this.CalendarCells)
                 {
                     var slotsPerCell = slots.Where(a => calendarCell.Date.Date >= a.Start.Date && calendarCell.Date.Date <= a.End.Date);
@@ -350,7 +358,17 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
                         if (startY < endY)
                         {
                             RadRect layoutSlot = new RadRect(calendarCell.layoutSlot.X - this.timeRulerWidth, startY, calendarCell.layoutSlot.Width, endY - startY);
-                            slot.layoutSlot = layoutSlot;
+
+                            var specialSlot = this.specialSlots.FirstOrDefault(a => a.Key == slot && a.Value.layoutSlot == RadRect.Empty);
+                            if (specialSlot.Value != null)
+                            {
+                                specialSlot.Value.layoutSlot = layoutSlot;
+                            }
+                            else
+                            {
+                                slot.layoutSlot = layoutSlot;
+                                this.specialSlots.Add(new KeyValuePair<Slot, Slot>(slot, slot.Copy()));
+                            }
                         }
                     }
                 }

--- a/Controls/Input/Input.UWP/Calendar/Model/ICopyable.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/ICopyable.cs
@@ -1,0 +1,16 @@
+﻿namespace Telerik.UI.Xaml.Controls.Input.Calendar
+{
+    /// <summary>
+    /// A generic interface for copying objects.
+    /// </summary>
+    public interface ICopyable<T>
+    {
+        /// <summary>
+        /// Deep copies this instance.
+        /// </summary>
+        /// <returns>
+        /// A <b>deep</b> copy of the current object.
+        /// </returns>
+        T Copy();
+    }
+}

--- a/Controls/Input/Input.UWP/Calendar/Model/Slot.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/Slot.cs
@@ -134,7 +134,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
                 return false;
             }
 
-            return (slot.Start <= this.start && this.end < slot.End) || (this.start <= slot.Start && slot.Start < this.end);
+            return (slot.Start <= this.start && this.start < slot.End) ||(this.start <= slot.Start && slot.Start < this.end);
         }
     }
 }

--- a/Controls/Input/Input.UWP/Calendar/Model/Slot.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/Slot.cs
@@ -7,7 +7,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
     /// <summary>
     /// A class that represents destination slot.
     /// </summary>
-    public class Slot : ViewModelBase
+    public class Slot : ViewModelBase, ICopyable<Slot>
     {
         internal RadRect layoutSlot;
 
@@ -125,6 +125,32 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
             }
 
             return base.Equals(obj);
+        }
+
+        /// <inheritdoc/>
+        public Slot Copy()
+        {
+            var slot = new Slot();
+            slot.CopyFrom(this);
+            return slot;
+        }
+
+        /// <summary>
+        /// <b>Deep</b> copies all properties from <paramref name="other"/> to this <see cref="Slot"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="Slot"/> which properties are copied.</param>
+        public virtual void CopyFrom(Slot other)
+        {
+            var otherSlot = other as Slot;
+            if (otherSlot == null)
+            {
+                return;
+            }
+
+            this.Start = other.Start;
+            this.End = other.End;
+            this.IsReadOnly = other.IsReadOnly;
+            this.layoutSlot = other.layoutSlot;
         }
 
         internal bool IntersectsWith(Slot slot)

--- a/Controls/Input/Input.UWP/Calendar/Model/Slot.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/Slot.cs
@@ -13,6 +13,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         private DateTime end;
         private DateTime start;
+        private bool isReadOnly;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Slot"/> class.
@@ -82,6 +83,28 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this slot is read only.
+        /// </summary>
+        /// <value>
+        /// 	<c>True</c> if this slot is read only; otherwise, <c>False</c>.
+        /// </value>
+        public bool IsReadOnly
+        {
+            get
+            {
+                return this.isReadOnly;
+            }
+            set
+            {
+                if (this.isReadOnly != value)
+                {
+                    this.isReadOnly = value;
+                    this.OnPropertyChanged(nameof(this.IsReadOnly));
+                }
+            }
+        }
+
+        /// <summary>
         /// Returns a <see cref="System.String"/> that represents this instance.
         /// </summary>
         /// <returns>
@@ -104,10 +127,14 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
             return base.Equals(obj);
         }
 
-        /// <inheritdoc/>
-        public override int GetHashCode()
+        internal bool IntersectsWith(Slot slot)
         {
-            return base.GetHashCode();
+            if (slot == null)
+            {
+                return false;
+            }
+
+            return (slot.Start <= this.start && this.end < slot.End) || (this.start <= slot.Start && slot.Start < this.end);
         }
     }
 }

--- a/Controls/Input/Input.UWP/Calendar/Model/Slot.cs
+++ b/Controls/Input/Input.UWP/Calendar/Model/Slot.cs
@@ -86,7 +86,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         /// Gets or sets a value indicating whether this slot is read only.
         /// </summary>
         /// <value>
-        /// 	<c>True</c> if this slot is read only; otherwise, <c>False</c>.
+        /// True if this slot is read only; otherwise, False.
         /// </value>
         public bool IsReadOnly
         {
@@ -134,7 +134,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
                 return false;
             }
 
-            return (slot.Start <= this.start && this.start < slot.End) ||(this.start <= slot.Start && slot.Start < this.end);
+            return (slot.Start <= this.start && this.start < slot.End) || (this.start <= slot.Start && slot.Start < this.end);
         }
     }
 }

--- a/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
@@ -345,7 +345,11 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
                     XamlContentLayer.ArrangeUIElement(slotVisual, slot.layoutSlot, true);
                     Canvas.SetLeft(slotVisual, slot.layoutSlot.X - this.leftOffset + this.leftHeaderPanel.Width);
-                    Canvas.SetZIndex(slotVisual, XamlMultiDayViewLayer.DefaultSlotZIndex);
+
+                    if (!this.IsCanvasZIndexExplicitlySet(slotVisual.Style))
+                    {
+                        Canvas.SetZIndex(slotVisual, XamlMultiDayViewLayer.DefaultSlotZIndex);
+                    }
                 }
             }
 
@@ -776,6 +780,22 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
                 foreach (Setter setter in style.Setters)
                 {
                     if (setter.Property == TextBlock.TextProperty)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsCanvasZIndexExplicitlySet(Style style)
+        {
+            if (style != null)
+            {
+                foreach (Setter setter in style.Setters)
+                {
+                    if (setter.Property == Canvas.ZIndexProperty)
                     {
                         return true;
                     }

--- a/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
@@ -350,6 +350,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
                 if (visual != null)
                 {
+                    XamlContentLayer.ArrangeUIElement(visual, slot.layoutSlot, true);
                     Canvas.SetLeft(visual, slot.layoutSlot.X - this.leftOffset + this.leftHeaderPanel.Width);
                     continue;
                 }

--- a/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
@@ -21,7 +21,6 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         private const int DefaultTopLeftHeaderZIndex = 1000;
         private const int DefaultToptHeaderZIndex = 500;
         private const int DefaultLeftHeaderZIndex = 750;
-        private const int DefaultSlotZIndex = 250;
         private const int DefaultTodaySlotZIndex = 200;
         private const int DefaultLineZIndex = 500;
         private const int DefaultCurrentTimeIndicatorZIndex = 750;
@@ -347,11 +346,6 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
                     XamlContentLayer.ArrangeUIElement(slotVisual, slot.layoutSlot, true);
                     Canvas.SetLeft(slotVisual, slot.layoutSlot.X - this.leftOffset + this.leftHeaderPanel.Width);
-
-                    if (!this.IsCanvasZIndexExplicitlySet(slotVisual.Style))
-                    {
-                        Canvas.SetZIndex(slotVisual, XamlMultiDayViewLayer.DefaultSlotZIndex);
-                    }
                 }
             }
 
@@ -782,22 +776,6 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
                 foreach (Setter setter in style.Setters)
                 {
                     if (setter.Property == TextBlock.TextProperty)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private bool IsCanvasZIndexExplicitlySet(Style style)
-        {
-            if (style != null)
-            {
-                foreach (Setter setter in style.Setters)
-                {
-                    if (setter.Property == Canvas.ZIndexProperty)
                     {
                         return true;
                     }

--- a/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
@@ -26,7 +26,6 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         private const int DefaultLineZIndex = 500;
         private const int DefaultCurrentTimeIndicatorZIndex = 750;
         private const int DefaultAppointmentZIndex = 1000;
-        private static SolidColorBrush DefaultBackground = new SolidColorBrush(Colors.White);
 
         private ScrollViewer scrollViewer;
         private Canvas leftHeaderPanel;
@@ -84,12 +83,12 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
             this.topLeftHeaderPanel = new Canvas();
             this.topLeftHeaderPanel.ManipulationMode = ManipulationModes.None;
-            this.topLeftHeaderPanel.Background = XamlMultiDayViewLayer.DefaultBackground;
+            this.topLeftHeaderPanel.Background = MultiDayViewSettings.DefaultBackground;
 
             Canvas.SetZIndex(this.topLeftHeaderPanel, DefaultTopLeftHeaderZIndex);
 
             this.topHeader = new Canvas();
-            this.topHeader.Background = XamlMultiDayViewLayer.DefaultBackground;
+            this.topHeader.Background = MultiDayViewSettings.DefaultBackground;
             this.topHeader.ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.System;
             Canvas.SetZIndex(this.topHeader, DefaultToptHeaderZIndex);
 
@@ -345,8 +344,8 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
                     }
 
                     XamlContentLayer.ArrangeUIElement(slotVisual, slot.layoutSlot, true);
-                    Canvas.SetZIndex(slotVisual, XamlMultiDayViewLayer.DefaultSlotZIndex);
                     Canvas.SetLeft(slotVisual, slot.layoutSlot.X - this.leftOffset + this.leftHeaderPanel.Width);
+                    Canvas.SetZIndex(slotVisual, XamlMultiDayViewLayer.DefaultSlotZIndex);
                 }
             }
 
@@ -623,7 +622,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal void UpdatePanelsBackground(Brush background)
         {
-            Brush defaultCalendarBrush = this.Owner.Background ?? XamlMultiDayViewLayer.DefaultBackground;
+            Brush defaultCalendarBrush = this.Owner.Background ?? MultiDayViewSettings.DefaultBackground;
             if (this.contentPanel.Background != background)
             {
                 if (background != null)
@@ -913,8 +912,8 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
                 visual.ClearValue(Border.VisibilityProperty);
                 visual.ClearValue(Border.StyleProperty);
-                visual.ClearValue(Border.BorderThicknessProperty);
                 visual.ClearValue(Canvas.ZIndexProperty);
+                visual.ClearValue(Canvas.LeftProperty);
             }
             else
             {

--- a/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/Layers/XamlMultiDayViewLayer.cs
@@ -157,10 +157,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
             this.UpdateTimeRulerItems(timeRulerItems);
             this.UpdateTimerRulerLines(timeRulerLines);
             this.UpdateAppointments(appointmentInfos);
-            if (slots != null)
-            {
-                this.UpdateSlots(slots);
-            }
+            this.UpdateSlots(slots);
 
             this.UpdateTodaySlot();
             this.UpdateCurrentTimeIndicator();
@@ -322,6 +319,11 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
 
         internal void UpdateSlots(IEnumerable<Slot> slots)
         {
+            if (slots == null)
+            {
+                return;
+            }
+
             foreach (var slot in slots)
             {
                 SlotControl visual;
@@ -334,7 +336,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
             foreach (var slot in slots)
             {
                 SlotControl visual;
-                this.realizedSlotPresenters.TryGetValue(slot, out visual);
+                this.visibleSlotPresenters.TryGetValue(slot, out visual);
 
                 if (!this.bufferedViewPortArea.IntersectsWith(slot.layoutSlot))
                 {

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/MultiDayViewSettings.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/MultiDayViewSettings.cs
@@ -161,6 +161,8 @@ namespace Telerik.UI.Xaml.Controls.Input
         public static readonly DependencyProperty WeekendsVisibleProperty =
             DependencyProperty.Register(nameof(WeekendsVisible), typeof(bool), typeof(MultiDayViewSettings), new PropertyMetadata(true, OnWeekendsVisibleChanged));
 
+        internal static SolidColorBrush DefaultBackground;
+
         internal const string DefaultAllDayText = "All-day";
         internal RadCalendar owner;
         internal DispatcherTimer timer;
@@ -665,6 +667,8 @@ namespace Telerik.UI.Xaml.Controls.Input
             this.defaultAllDayAreaBorderStyle = this.defaultAllDayAreaBorderStyle ?? (Style)dictionary["AllDayAreaBorderStyle"];
             this.defaultAllDayAreaTextStyle = this.defaultAllDayAreaTextStyle ?? (Style)dictionary["DefaultAllDayTextBlockStyle"];
             this.defaulTodaySlotStyle = this.defaulTodaySlotStyle ?? (Style)dictionary["TodaySlotStyle"];
+            this.defaultSpecialSlotStyleSelector = this.defaultSpecialSlotStyleSelector ?? (SpecialSlotStyleSelector)dictionary["SpecialSlotStyleSelector"];
+            MultiDayViewSettings.DefaultBackground = (SolidColorBrush)dictionary["TelerikCalendarBackgroundBrush"];
         }
 
         internal void DetachEvents()

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/MultiDayViewSettings.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/MultiDayViewSettings.cs
@@ -161,9 +161,9 @@ namespace Telerik.UI.Xaml.Controls.Input
         public static readonly DependencyProperty WeekendsVisibleProperty =
             DependencyProperty.Register(nameof(WeekendsVisible), typeof(bool), typeof(MultiDayViewSettings), new PropertyMetadata(true, OnWeekendsVisibleChanged));
 
+        internal const string DefaultAllDayText = "All-day";
         internal static SolidColorBrush DefaultBackground;
 
-        internal const string DefaultAllDayText = "All-day";
         internal RadCalendar owner;
         internal DispatcherTimer timer;
 

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/MultiDayViewSettings.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/MultiDayViewSettings.cs
@@ -616,7 +616,7 @@ namespace Telerik.UI.Xaml.Controls.Input
                         }
                     }
 
-                    this.owner.timeRulerLayer?.RecycleSlots(e.OldItems.Cast<Slot>());
+                    this.owner.timeRulerLayer?.RecycleModelSlots(e.OldItems.Cast<Slot>());
                     break;
                 case NotifyCollectionChangedAction.Move:
                 case NotifyCollectionChangedAction.Replace:
@@ -912,7 +912,7 @@ namespace Telerik.UI.Xaml.Controls.Input
 
             if (oldSlotsSource != null && settings.IsOwnerLoaded)
             {
-                settings.owner.timeRulerLayer.RecycleSlots((IEnumerable<Slot>)oldSlotsSource);
+                settings.owner.timeRulerLayer.RecycleModelSlots((IEnumerable<Slot>)oldSlotsSource);
             }
 
             settings.Invalide(MultiDayViewUpdateFlag.AffectsSpecialSlots);
@@ -925,7 +925,7 @@ namespace Telerik.UI.Xaml.Controls.Input
 
             if (settings.IsOwnerLoaded)
             {
-                settings.owner.timeRulerLayer.UpdateSlots(settings.SpecialSlotsSource);
+                settings.owner.timeRulerLayer.UpdateSlots();
             }
         }
 

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SlotControl.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SlotControl.cs
@@ -1,5 +1,8 @@
 ﻿namespace Telerik.UI.Xaml.Controls.Input.Calendar
 {
+    /// <summary>
+    /// Represents the custom <see cref="SlotControl"/> implementation used to visualize the UI of the special slots in a cell.
+    /// </summary>
     public class SlotControl : RadContentControl
     {
         /// <summary>

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SlotControl.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SlotControl.cs
@@ -1,0 +1,13 @@
+﻿namespace Telerik.UI.Xaml.Controls.Input.Calendar
+{
+    public class SlotControl : RadContentControl
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SlotControl"/> class.
+        /// </summary>
+        public SlotControl()
+        {
+            this.DefaultStyleKey = typeof(SlotControl);
+        }
+    }
+}

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SpecialSlotStyleSelector.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SpecialSlotStyleSelector.cs
@@ -1,0 +1,43 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Telerik.UI.Xaml.Controls.Input.Calendar
+{
+    /// <summary>
+    /// Provides a way to choose a style for the SpecialSlot based on the data object and the
+    /// data-bound element.
+    /// </summary>
+    [Bindable]
+    [StyleTypedProperty(Property = "DefaultStyle", StyleTargetType = typeof(Border))]
+    [StyleTypedProperty(Property = "ReadOnlyStyle", StyleTargetType = typeof(Border))]
+    public class SpecialSlotStyleSelector : StyleSelector
+    {
+        /// <summary>
+        /// Gets or sets the default style of the SpecialSlot.
+        /// </summary>
+		public Style DefaultStyle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the read-only style of the SpecialSlot.
+        /// </summary>
+		public Style ReadOnlyStyle { get; set; }
+
+        /// <summary>
+        /// When overridden in a derived class, returns a Style based on custom logic.
+        /// </summary>
+        /// <param name="item">The content.</param>
+        /// <param name="container">The element to which the style will be applied.</param>
+        /// <returns>Returns an application-specific style to apply; otherwise, null.</returns>
+		protected override Style SelectStyleCore(object item, DependencyObject container)
+        {
+            Slot slot = item as Slot;
+            if (slot != null && slot.IsReadOnly)
+            {
+                return this.ReadOnlyStyle;
+            }
+
+            return this.DefaultStyle;
+        }
+    }
+}

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SpecialSlotStyleSelector.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SpecialSlotStyleSelector.cs
@@ -16,12 +16,12 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         /// <summary>
         /// Gets or sets the default style of the SpecialSlot.
         /// </summary>
-		public Style DefaultStyle { get; set; }
+        public Style DefaultStyle { get; set; }
 
         /// <summary>
         /// Gets or sets the read-only style of the SpecialSlot.
         /// </summary>
-		public Style ReadOnlyStyle { get; set; }
+        public Style ReadOnlyStyle { get; set; }
 
         /// <summary>
         /// When overridden in a derived class, returns a Style based on custom logic.

--- a/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SpecialSlotStyleSelector.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/MultiDayView/SpecialSlotStyleSelector.cs
@@ -29,7 +29,7 @@ namespace Telerik.UI.Xaml.Controls.Input.Calendar
         /// <param name="item">The content.</param>
         /// <param name="container">The element to which the style will be applied.</param>
         /// <returns>Returns an application-specific style to apply; otherwise, null.</returns>
-		protected override Style SelectStyleCore(object item, DependencyObject container)
+        protected override Style SelectStyleCore(object item, DependencyObject container)
         {
             Slot slot = item as Slot;
             if (slot != null && slot.IsReadOnly)

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.Manipulations.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.Manipulations.cs
@@ -205,11 +205,9 @@ namespace Telerik.UI.Xaml.Controls.Input
                 Point hitPoint = e.GetPosition(this.timeRulerLayer.contentPanel);
                 CalendarMultiDayViewModel multiDayViewModel = this.model.multiDayViewModel;
                 hitPoint.X += multiDayViewModel.timeRulerWidth;
-                Slot slot = HitTestService.GetSlotFromPoint(hitPoint, multiDayViewModel.timeRulerItems, this.model.CalendarCells, this.MultiDayViewSettings.VisibleDays);
-                if (slot != null)
-                {
-                    this.commandService.ExecuteCommand(CommandId.TimeSlotTap, slot);
-                }
+
+                Slot slot = this.hitTestService.GetSlotFromPoint(hitPoint);
+                this.commandService.ExecuteCommand(CommandId.TimeSlotTap, slot);
             }
         }
 

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -2353,6 +2353,7 @@ namespace Telerik.UI.Xaml.Controls.Input
         {
             base.UnloadCore();
             this.availableCalendarViewSize = new Size(0, 0);
+            this.UnloadMultiDayView();
         }
 
         /// <summary>
@@ -2955,6 +2956,10 @@ namespace Telerik.UI.Xaml.Controls.Input
             RadCalendar.RemoveLayer(this.allDayAreaLayer, this.calendarViewHost);
             RadCalendar.RemoveLayer(this.timeRulerLayer, this.calendarViewHost);
             RadCalendar.RemoveLayer(this.appointmentLayer, this.calendarViewHost);
+        }
+
+        private void UnloadMultiDayView()
+        {
             this.appointmentSourceCollectionChangedListener?.Detach();
             if (this.appointmentSourcePropertyChangedListeners != null && this.appointmentSourcePropertyChangedListeners.Count > 0)
             {

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -3244,7 +3244,7 @@ namespace Telerik.UI.Xaml.Controls.Input
                         IEnumerable<Slot> slots = this.MultiDayViewSettings.SpecialSlotsSource;
                         if (slots != null)
                         {
-                            this.timeRulerLayer.UpdateSlots(this.MultiDayViewSettings.SpecialSlotsSource);
+                            this.timeRulerLayer.UpdateSlots(slots);
                         }
 
                         break;

--- a/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
+++ b/Controls/Input/Input.UWP/Calendar/View/RadCalendar.cs
@@ -3252,12 +3252,7 @@ namespace Telerik.UI.Xaml.Controls.Input
                         this.timeRulerLayer.UpdateCurrentTimeIndicator();
                         break;
                     case MultiDayViewUpdateFlag.AffectsSpecialSlots:
-                        IEnumerable<Slot> slots = this.MultiDayViewSettings.SpecialSlotsSource;
-                        if (slots != null)
-                        {
-                            this.timeRulerLayer.UpdateSlots(slots);
-                        }
-
+                        this.timeRulerLayer.UpdateSlots();
                         break;
                     default:
                         break;

--- a/Controls/Input/Input.UWP/Input.UWP.csproj
+++ b/Controls/Input/Input.UWP/Input.UWP.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Calendar\AutomationPeers\RadCalendarAutomationPeer.cs" />
     <Compile Include="Calendar\Model\CalendarTimeRulerItem.cs" />
     <Compile Include="Calendar\Model\CalendarMultiDayViewModel.cs" />
+    <Compile Include="Calendar\Model\ICopyable.cs" />
     <Compile Include="Calendar\Model\Slot.cs" />
     <Compile Include="Calendar\View\Layers\XamlAllDayAreaLayer.cs" />
     <Compile Include="Calendar\View\Layers\XamlMultiDayViewLayer.cs" />

--- a/Controls/Input/Input.UWP/Input.UWP.csproj
+++ b/Controls/Input/Input.UWP/Input.UWP.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Calendar\View\MultiDayView\MultiDayViewSettings.cs" />
     <Compile Include="Calendar\View\MultiDayView\MultiDayViewUpdateFlag.cs" />
     <Compile Include="Calendar\View\MultiDayView\CalendarTimeRulerItemStyleSelector.cs" />
+    <Compile Include="Calendar\View\MultiDayView\SlotControl.cs" />
     <Compile Include="Calendar\View\MultiDayView\SpecialSlotStyleSelector.cs" />
     <Compile Include="DateTimePicker\AutomationPeers\DateTimeListAutomationPeer.cs" />
     <Compile Include="DateTimePicker\AutomationPeers\DateTimeListItemAutomationPeer.cs" />

--- a/Controls/Input/Input.UWP/Input.UWP.csproj
+++ b/Controls/Input/Input.UWP/Input.UWP.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Calendar\View\MultiDayView\MultiDayViewSettings.cs" />
     <Compile Include="Calendar\View\MultiDayView\MultiDayViewUpdateFlag.cs" />
     <Compile Include="Calendar\View\MultiDayView\CalendarTimeRulerItemStyleSelector.cs" />
+    <Compile Include="Calendar\View\MultiDayView\SpecialSlotStyleSelector.cs" />
     <Compile Include="DateTimePicker\AutomationPeers\DateTimeListAutomationPeer.cs" />
     <Compile Include="DateTimePicker\AutomationPeers\DateTimeListItemAutomationPeer.cs" />
     <Compile Include="DateTimePicker\AutomationPeers\DateTimePickerAutomationPeer.cs" />

--- a/Controls/Input/Input.UWP/Themes/Calendar.xaml
+++ b/Controls/Input/Input.UWP/Themes/Calendar.xaml
@@ -79,6 +79,22 @@
         </Setter>
     </Style>
 
+    <Style TargetType="localCalendar:SlotControl">
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="BorderBrush" Value="{x:Null}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="localCalendar:SlotControl">
+                    <ContentPresenter Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      Background="{TemplateBinding Background}"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="CalendarLeftArrowButtonStyle" TargetType="Button">
         <Setter Property="Foreground" Value="{ThemeResource TelerikCalendarPreviousNextButtonForegroundBrush}" />
         <Setter Property="FontSize" Value="18" />

--- a/Controls/Input/Input.UWP/Themes/Calendar.xaml
+++ b/Controls/Input/Input.UWP/Themes/Calendar.xaml
@@ -82,6 +82,7 @@
     <Style TargetType="localCalendar:SlotControl">
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="BorderBrush" Value="{x:Null}"/>
+        <Setter Property="Canvas.ZIndex" Value="250"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="localCalendar:SlotControl">

--- a/Controls/Input/Input.UWP/Themes/DefaultCalendarTimerRulerResources.xaml
+++ b/Controls/Input/Input.UWP/Themes/DefaultCalendarTimerRulerResources.xaml
@@ -25,8 +25,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="TodaySlotStyle" TargetType="Border">
-        <Setter Property="Background" Value="#FFF5F5F5"/>
-        <Setter Property="Opacity" Value="0.5"/>
+        <Setter Property="Background" Value="{ThemeResource TelerikTodayMultiDayViewBackground}"/>
     </Style>
 
     <Style x:Key="CurrentTimeIndicatorStyle" TargetType="Border">

--- a/Controls/Input/Input.UWP/Themes/DefaultCalendarTimerRulerResources.xaml
+++ b/Controls/Input/Input.UWP/Themes/DefaultCalendarTimerRulerResources.xaml
@@ -62,11 +62,6 @@
         <Setter Property="Margin" Value="6,0,0,4" />
     </Style>
 
-    <Style x:Key="DefaultSpecialSlotBorderStyle" TargetType="Border">
-        <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="BorderBrush" Value="{x:Null}" />
-    </Style>
-
     <local:CalendarCellStyle x:Key="NormalCellStyle">
         <local:CalendarCellStyle.ContentStyle>
             <Style TargetType="TextBlock" BasedOn="{StaticResource DefaultNormalCellStyle}">
@@ -165,12 +160,12 @@
 
     <localCalendar:SpecialSlotStyleSelector x:Key="SpecialSlotStyleSelector">
         <localCalendar:SpecialSlotStyleSelector.DefaultStyle>
-            <Style TargetType="Border">
+            <Style TargetType="localCalendar:SlotControl">
                 <Setter Property="Background" Value="{StaticResource TelerikSpecialSlotBackground}" />
             </Style>
         </localCalendar:SpecialSlotStyleSelector.DefaultStyle>
         <localCalendar:SpecialSlotStyleSelector.ReadOnlyStyle>
-            <Style TargetType="Border">
+            <Style TargetType="localCalendar:SlotControl">
                 <Setter Property="Background" Value="{StaticResource TelerikSpecialSlotBackgroundReadOnly}" />
             </Style>
         </localCalendar:SpecialSlotStyleSelector.ReadOnlyStyle>

--- a/Controls/Input/Input.UWP/Themes/DefaultCalendarTimerRulerResources.xaml
+++ b/Controls/Input/Input.UWP/Themes/DefaultCalendarTimerRulerResources.xaml
@@ -25,7 +25,8 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="TodaySlotStyle" TargetType="Border">
-        <Setter Property="Background" Value="#FFFAFAFA"/>
+        <Setter Property="Background" Value="#FFF5F5F5"/>
+        <Setter Property="Opacity" Value="0.5"/>
     </Style>
 
     <Style x:Key="CurrentTimeIndicatorStyle" TargetType="Border">
@@ -59,6 +60,11 @@
     <Style x:Key="DefaultAnotherViewCellStyle" TargetType="TextBlock">
         <Setter Property="Foreground" Value="{ThemeResource TelerikCalendarAnotherViewCellForegroundBrush}" />
         <Setter Property="Margin" Value="6,0,0,4" />
+    </Style>
+
+    <Style x:Key="DefaultSpecialSlotBorderStyle" TargetType="Border">
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="BorderBrush" Value="{x:Null}" />
     </Style>
 
     <local:CalendarCellStyle x:Key="NormalCellStyle">
@@ -156,4 +162,17 @@
             </Style>
         </localCalendar:CalendarTimeRulerItemStyleSelector.TimeLabelStyle>
     </localCalendar:CalendarTimeRulerItemStyleSelector>
+
+    <localCalendar:SpecialSlotStyleSelector x:Key="SpecialSlotStyleSelector">
+        <localCalendar:SpecialSlotStyleSelector.DefaultStyle>
+            <Style TargetType="Border">
+                <Setter Property="Background" Value="{StaticResource TelerikSpecialSlotBackground}" />
+            </Style>
+        </localCalendar:SpecialSlotStyleSelector.DefaultStyle>
+        <localCalendar:SpecialSlotStyleSelector.ReadOnlyStyle>
+            <Style TargetType="Border">
+                <Setter Property="Background" Value="{StaticResource TelerikSpecialSlotBackgroundReadOnly}" />
+            </Style>
+        </localCalendar:SpecialSlotStyleSelector.ReadOnlyStyle>
+    </localCalendar:SpecialSlotStyleSelector>
 </ResourceDictionary>

--- a/Controls/Input/Input.UWP/Themes/ThemeResourcesDark.xaml
+++ b/Controls/Input/Input.UWP/Themes/ThemeResourcesDark.xaml
@@ -260,18 +260,11 @@
     <SolidColorBrush x:Key="TelerikCalendarCurrentCellBorderBrush" Color="#FF0066CC" />
 
     <!--SpecialSlots-->
-    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="Red" Opacity="0.5"/>
-    <LinearGradientBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" 
-                         MappingMode="Absolute" 
-                         SpreadMethod="Repeat" 
-                         StartPoint="0,0" 
-                         EndPoint="1,1">
-        <LinearGradientBrush.Transform>
-            <ScaleTransform ScaleX="3" ScaleY="3" />
-        </LinearGradientBrush.Transform>
-        <GradientStop Offset="0.15" Color="#FF4040C2" />
-        <GradientStop Offset="0.15" Color="White" />
-    </LinearGradientBrush>
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="#919191" Opacity="0.4"/>
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" Color="#919191" Opacity="0.7"/>
+
+    <!--Today MultiDayView-->
+    <SolidColorBrush x:Key="TelerikTodayMultiDayViewBackground" Color="#898989"/>
 
     <!--#endregion-->
 </ResourceDictionary>

--- a/Controls/Input/Input.UWP/Themes/ThemeResourcesDark.xaml
+++ b/Controls/Input/Input.UWP/Themes/ThemeResourcesDark.xaml
@@ -259,5 +259,19 @@
 
     <SolidColorBrush x:Key="TelerikCalendarCurrentCellBorderBrush" Color="#FF0066CC" />
 
+    <!--SpecialSlots-->
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="Red" Opacity="0.5"/>
+    <LinearGradientBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" 
+                         MappingMode="Absolute" 
+                         SpreadMethod="Repeat" 
+                         StartPoint="0,0" 
+                         EndPoint="1,1">
+        <LinearGradientBrush.Transform>
+            <ScaleTransform ScaleX="3" ScaleY="3" />
+        </LinearGradientBrush.Transform>
+        <GradientStop Offset="0.15" Color="#FF4040C2" />
+        <GradientStop Offset="0.15" Color="White" />
+    </LinearGradientBrush>
+
     <!--#endregion-->
 </ResourceDictionary>

--- a/Controls/Input/Input.UWP/Themes/ThemeResourcesHighContrast.xaml
+++ b/Controls/Input/Input.UWP/Themes/ThemeResourcesHighContrast.xaml
@@ -258,5 +258,20 @@
 
     <SolidColorBrush x:Key="TelerikCalendarCurrentCellBorderBrush" Color="{ThemeResource SystemColorHighlightColor}" />
 
+    <!--SpecialSlots-->
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="{ThemeResource SystemColorWindowColor}" />
+    <LinearGradientBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" 
+                         MappingMode="Absolute" 
+                         SpreadMethod="Repeat" 
+                         StartPoint="0,0" 
+                         EndPoint="1,1">
+        <LinearGradientBrush.Transform>
+            <ScaleTransform ScaleX="3" ScaleY="3" />
+        </LinearGradientBrush.Transform>
+        <GradientStop Offset="0.15" Color="{ThemeResource SystemColorGrayTextColor}" />
+        <GradientStop Offset="0.15" Color="White" />
+    </LinearGradientBrush>
+
+
     <!--#endregion-->
 </ResourceDictionary>

--- a/Controls/Input/Input.UWP/Themes/ThemeResourcesHighContrast.xaml
+++ b/Controls/Input/Input.UWP/Themes/ThemeResourcesHighContrast.xaml
@@ -257,20 +257,13 @@
     <SolidColorBrush x:Key="TelerikCalendarPointerOverBorderBrush" Color="{ThemeResource SystemColorHighlightTextColor}" />
 
     <SolidColorBrush x:Key="TelerikCalendarCurrentCellBorderBrush" Color="{ThemeResource SystemColorHighlightColor}" />
-
+    
     <!--SpecialSlots-->
-    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="{ThemeResource SystemColorWindowColor}" />
-    <LinearGradientBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" 
-                         MappingMode="Absolute" 
-                         SpreadMethod="Repeat" 
-                         StartPoint="0,0" 
-                         EndPoint="1,1">
-        <LinearGradientBrush.Transform>
-            <ScaleTransform ScaleX="3" ScaleY="3" />
-        </LinearGradientBrush.Transform>
-        <GradientStop Offset="0.15" Color="{ThemeResource SystemColorGrayTextColor}" />
-        <GradientStop Offset="0.15" Color="White" />
-    </LinearGradientBrush>
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="{ThemeResource SystemColorHotlightColor}" Opacity="0.9"/>
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" Color="{ThemeResource SystemColorGrayTextColor}" Opacity="0.7"/>
+
+    <!--Today MultiDayView-->
+    <SolidColorBrush x:Key="TelerikTodayMultiDayViewBackground" Color="{ThemeResource SystemColorHighlightColor}" Opacity="0.9"/>
 
 
     <!--#endregion-->

--- a/Controls/Input/Input.UWP/Themes/ThemeResourcesLight.xaml
+++ b/Controls/Input/Input.UWP/Themes/ThemeResourcesLight.xaml
@@ -259,5 +259,20 @@
 
     <SolidColorBrush x:Key="TelerikCalendarCurrentCellBorderBrush" Color="#FF0066CC" />
 
+    <!--SpecialSlots-->
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="Red" Opacity="0.5"/>
+    <LinearGradientBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" 
+                         MappingMode="Absolute" 
+                         SpreadMethod="Repeat" 
+                         StartPoint="0,0" 
+                         EndPoint="1,1">
+        <LinearGradientBrush.Transform>
+            <ScaleTransform ScaleX="3" ScaleY="3" />
+        </LinearGradientBrush.Transform>
+        <GradientStop Offset="0.15" Color="#FF4040C2" />
+        <GradientStop Offset="0.15" Color="White" />
+    </LinearGradientBrush>
+
+
     <!--#endregion-->
 </ResourceDictionary>

--- a/Controls/Input/Input.UWP/Themes/ThemeResourcesLight.xaml
+++ b/Controls/Input/Input.UWP/Themes/ThemeResourcesLight.xaml
@@ -260,19 +260,18 @@
     <SolidColorBrush x:Key="TelerikCalendarCurrentCellBorderBrush" Color="#FF0066CC" />
 
     <!--SpecialSlots-->
-    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="Red" Opacity="0.5"/>
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="#FFF5F5F5"/>
     <LinearGradientBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" 
                          MappingMode="Absolute" 
                          SpreadMethod="Repeat" 
-                         StartPoint="0,0" 
-                         EndPoint="1,1">
+                         StartPoint="1,0" 
+                         EndPoint="0,1">
         <LinearGradientBrush.Transform>
-            <ScaleTransform ScaleX="3" ScaleY="3" />
+            <ScaleTransform ScaleX="2.5" ScaleY="2.5" />
         </LinearGradientBrush.Transform>
-        <GradientStop Offset="0.15" Color="#FF4040C2" />
-        <GradientStop Offset="0.15" Color="White" />
+        <GradientStop Offset="0.75" Color="#FFF5F5F5" />
+        <GradientStop Offset="0.75" Color="#FF707070"/>
     </LinearGradientBrush>
-
 
     <!--#endregion-->
 </ResourceDictionary>

--- a/Controls/Input/Input.UWP/Themes/ThemeResourcesLight.xaml
+++ b/Controls/Input/Input.UWP/Themes/ThemeResourcesLight.xaml
@@ -260,18 +260,11 @@
     <SolidColorBrush x:Key="TelerikCalendarCurrentCellBorderBrush" Color="#FF0066CC" />
 
     <!--SpecialSlots-->
-    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="#FFF5F5F5"/>
-    <LinearGradientBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" 
-                         MappingMode="Absolute" 
-                         SpreadMethod="Repeat" 
-                         StartPoint="1,0" 
-                         EndPoint="0,1">
-        <LinearGradientBrush.Transform>
-            <ScaleTransform ScaleX="2.5" ScaleY="2.5" />
-        </LinearGradientBrush.Transform>
-        <GradientStop Offset="0.75" Color="#FFF5F5F5" />
-        <GradientStop Offset="0.75" Color="#FF707070"/>
-    </LinearGradientBrush>
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackground" Color="#919191" Opacity="0.5"/>
+    <SolidColorBrush x:Key="TelerikSpecialSlotBackgroundReadOnly" Color="#CCCCCC" Opacity="0.6"/>
+
+    <!--Today MultiDayView-->
+    <SolidColorBrush x:Key="TelerikTodayMultiDayViewBackground" Color="#FFF5F5F5" Opacity="0.5"/>
 
     <!--#endregion-->
 </ResourceDictionary>

--- a/SDKExamples.UWP/Examples/Calendar/MultiDayView.xaml
+++ b/SDKExamples.UWP/Examples/Calendar/MultiDayView.xaml
@@ -1,12 +1,12 @@
 ﻿<local:ExamplePageBase
     x:Class="SDKExamples.UWP.Calendar.MultiDayView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:input="using:Telerik.UI.Xaml.Controls.Input"
     xmlns:local="using:SDKExamples.UWP"
     xmlns:example="using:SDKExamples.UWP.Calendar"
+    xmlns:input="using:Telerik.UI.Xaml.Controls.Input"
     xmlns:primitives="using:Telerik.UI.Xaml.Controls.Primitives"
     xmlns:sideDrawer="using:Telerik.UI.Xaml.Controls.Primitives.SideDrawer"
     mc:Ignorable="d" x:Name="page">
@@ -34,8 +34,12 @@
                                    DisplayMode="MultiDayView"
                                    GridLinesThickness="{Binding SelectedThickness}"
                                    AppointmentSource="{Binding Appointments}">
+                    <input:RadCalendar.Commands>
+                        <example:SlotTapCommand/>
+                    </input:RadCalendar.Commands>
                     <input:RadCalendar.MultiDayViewSettings>
                         <input:MultiDayViewSettings VisibleDays="{Binding SelectedVisibleDays, Mode=TwoWay}" 
+                                                    SpecialSlotsSource="{Binding NonWorkingHours}"
                                                     TimerRulerTickLength="{Binding SelectedTickLength, Converter={StaticResource StringToTimeSpanConverter}, Mode=TwoWay}"
                                                     DayStartTime="{Binding StartTimeValue, Converter={StaticResource StringToTimeSpanConverter}, Mode=TwoWay}"
                                                     DayEndTime="{Binding EndTimeValue, Converter={StaticResource StringToTimeSpanConverter}, Mode=TwoWay}"

--- a/SDKExamples.UWP/Examples/Calendar/MultiDayView.xaml.cs
+++ b/SDKExamples.UWP/Examples/Calendar/MultiDayView.xaml.cs
@@ -488,21 +488,4 @@ namespace SDKExamples.UWP.Calendar
             throw new NotImplementedException();
         }
     }
-
-    public class TestStyle : StyleSelector
-    {
-        public Style NonWorkingHours { get; set; }
-        public Style SpecialHours { get; set; }
-
-        protected override Style SelectStyleCore(object item, DependencyObject container)
-        {
-            Slot slot = (Slot)item;
-            if (slot.IsReadOnly)
-            {
-                return this.NonWorkingHours;
-            }
-
-            return this.SpecialHours;
-        }
-    }
 }

--- a/SDKExamples.UWP/Examples/Calendar/MultiDayViewStyling.xaml
+++ b/SDKExamples.UWP/Examples/Calendar/MultiDayViewStyling.xaml
@@ -13,12 +13,12 @@
     <local:ExamplePageBase.Resources>
         <example:NonWorkingHoursSpecialSlotStyleSelector x:Key="NonWorkingHoursSpecialSlotStyleSelector">
             <example:NonWorkingHoursSpecialSlotStyleSelector.NonWorkingHours>
-                <Style TargetType="Border">
+                <Style TargetType="calendar:SlotControl">
                     <Setter Property="Background" Value="LightGray"/>
                 </Style>
             </example:NonWorkingHoursSpecialSlotStyleSelector.NonWorkingHours>
             <example:NonWorkingHoursSpecialSlotStyleSelector.SpecialHours>
-                <Style TargetType="Border">
+                <Style TargetType="calendar:SlotControl">
                     <Setter Property="Background" Value="Green"/>
                 </Style>
             </example:NonWorkingHoursSpecialSlotStyleSelector.SpecialHours>

--- a/SDKExamples.UWP/Examples/Calendar/MultiDayViewStyling.xaml.cs
+++ b/SDKExamples.UWP/Examples/Calendar/MultiDayViewStyling.xaml.cs
@@ -237,7 +237,7 @@ namespace SDKExamples.UWP.Calendar
             ContentDialog dialog = new ContentDialog
             {
                 Title = "SlotTapped",
-                Content = "Slot Start: " + slot.Start + " End: " + slot.End + " was tapped.",
+                Content = "Slot Start: " + slot.Start + " End: " + slot.End + " was tapped and IsReadOnly: " + slot.IsReadOnly + ".",
                 PrimaryButtonText = "OK"
             };
 


### PR DESCRIPTION
- Added a default Style selector - thus the slots have a default look.
- Improve the virtualization of the slots.
- Fix a bug where wrong slot was tapped when the weekends were not visible.
- Change the visual element of the slot from Border to SlotControl in order to support Content for the slot.
- Minor bug fixes that were affecting the performance of the control and its look in Dark mode theme.