### PR TITLE
Fix order of operations bug in DataGrid SelectItem and SelectCell

### DIFF
--- a/Controls/Grid/Grid.UWP/View/RadDataGrid.Selection.cs
+++ b/Controls/Grid/Grid.UWP/View/RadDataGrid.Selection.cs
@@ -127,8 +127,8 @@ namespace Telerik.UI.Xaml.Controls.Grid
         /// </remarks>
         public void SelectItem(object item)
         {
-            this.selectionService.SelectItem(item, true, false);
             this.UpdateItemToSelectFrom(item);
+            this.selectionService.SelectItem(item, true, false);
         }
 
         /// <summary>
@@ -158,8 +158,8 @@ namespace Telerik.UI.Xaml.Controls.Grid
         /// </remarks>
         public void SelectCell(DataGridCellInfo item)
         {
-            this.selectionService.SelectCellInfo(item, true, false);
             this.UpdateItemToSelectFrom(item);
+            this.selectionService.SelectCellInfo(item, true, false);
         }
 
         /// <summary>


### PR DESCRIPTION
When using the DataGrid's extended selection mode, SelectItem and SelectCell would only briefly select the desired item but then would clear the selection leaving nothing selected. This change fixes the order of operations so that the selection is cleared first before making the new selection.

Fix for: https://github.com/telerik/UI-For-UWP/issues/462