### PR TITLE
Fix a bug that DrawerLocation cannot be changed dynamically

### DIFF
--- a/Controls/Primitives/Primitives.UWP/SideDrawer/Commands/AnimationContext.cs
+++ b/Controls/Primitives/Primitives.UWP/SideDrawer/Commands/AnimationContext.cs
@@ -32,12 +32,21 @@ namespace Telerik.UI.Xaml.Controls.Primitives.SideDrawer.Commands
         /// </summary>
         public Storyboard DrawerStoryBoardReverse { get; set; }
 
+        internal DrawerLocation DrawerLocation { get; set; }
+
+        internal DrawerTransition DrawerTransition { get; set; }
+
         internal bool IsGenerated
         {
             get
             {
                 return this.MainContentStoryBoard != null && this.MainContentStoryBoardReverse != null && this.DrawerStoryBoard != null && this.DrawerStoryBoardReverse != null;
             }        
+        }
+
+        internal bool IsContextValid(DrawerLocation location, DrawerTransition transition)
+        {
+            return this.IsGenerated && this.DrawerLocation == location && this.DrawerTransition == transition;
         }
     }
 }

--- a/Controls/Primitives/Primitives.UWP/SideDrawer/RadSideDrawer.AnimationGenerator.cs
+++ b/Controls/Primitives/Primitives.UWP/SideDrawer/RadSideDrawer.AnimationGenerator.cs
@@ -66,7 +66,7 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                     return this.GetSlideAlongAnimations();
 
                 default:
-                    return new AnimationContext();
+                    return new AnimationContext() { DrawerLocation = this.DrawerLocation, DrawerTransition = this.DrawerTransition };
             }
         }
 
@@ -165,7 +165,9 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                 MainContentStoryBoard = this.mainContentStoryboard,
                 MainContentStoryBoardReverse = this.mainContentStoryboardReverse,
                 DrawerStoryBoardReverse = this.sideBarStoryboardReverse,
-                DrawerStoryBoard = this.sideBarStoryboard
+                DrawerStoryBoard = this.sideBarStoryboard,
+                DrawerLocation = this.DrawerLocation,
+                DrawerTransition = this.DrawerTransition
             };
         }
 
@@ -259,7 +261,9 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                 MainContentStoryBoard = this.mainContentStoryboard,
                 MainContentStoryBoardReverse = this.mainContentStoryboardReverse,
                 DrawerStoryBoardReverse = this.sideBarStoryboardReverse,
-                DrawerStoryBoard = this.sideBarStoryboard
+                DrawerStoryBoard = this.sideBarStoryboard,
+                DrawerLocation = this.DrawerLocation,
+                DrawerTransition = this.DrawerTransition
             };
         }
 
@@ -400,7 +404,9 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                 MainContentStoryBoard = this.mainContentStoryboard,
                 MainContentStoryBoardReverse = this.mainContentStoryboardReverse,
                 DrawerStoryBoardReverse = this.sideBarStoryboardReverse,
-                DrawerStoryBoard = this.sideBarStoryboard
+                DrawerStoryBoard = this.sideBarStoryboard,
+                DrawerLocation = this.DrawerLocation,
+                DrawerTransition = this.DrawerTransition
             };
         }
 
@@ -509,7 +515,9 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                 MainContentStoryBoard = this.mainContentStoryboard,
                 MainContentStoryBoardReverse = this.mainContentStoryboardReverse,
                 DrawerStoryBoardReverse = this.sideBarStoryboardReverse,
-                DrawerStoryBoard = this.sideBarStoryboard
+                DrawerStoryBoard = this.sideBarStoryboard,
+                DrawerLocation = this.DrawerLocation,
+                DrawerTransition = this.DrawerTransition
             };
         }
 
@@ -651,7 +659,9 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                 MainContentStoryBoard = this.mainContentStoryboard,
                 MainContentStoryBoardReverse = this.mainContentStoryboardReverse,
                 DrawerStoryBoardReverse = this.sideBarStoryboardReverse,
-                DrawerStoryBoard = this.sideBarStoryboard
+                DrawerStoryBoard = this.sideBarStoryboard,
+                DrawerLocation = this.DrawerLocation,
+                DrawerTransition = this.DrawerTransition
             };
         }
 
@@ -718,7 +728,9 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                 MainContentStoryBoard = this.mainContentStoryboard,
                 MainContentStoryBoardReverse = this.mainContentStoryboardReverse,
                 DrawerStoryBoardReverse = this.sideBarStoryboardReverse,
-                DrawerStoryBoard = this.sideBarStoryboard
+                DrawerStoryBoard = this.sideBarStoryboard,
+                DrawerLocation = this.DrawerLocation,
+                DrawerTransition = this.DrawerTransition
             };
         }
 
@@ -842,7 +854,9 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                 MainContentStoryBoard = this.mainContentStoryboard,
                 MainContentStoryBoardReverse = this.mainContentStoryboardReverse,
                 DrawerStoryBoardReverse = this.sideBarStoryboardReverse,
-                DrawerStoryBoard = this.sideBarStoryboard
+                DrawerStoryBoard = this.sideBarStoryboard,
+                DrawerLocation = this.DrawerLocation,
+                DrawerTransition = this.DrawerTransition
             };
         }
 

--- a/Controls/Primitives/Primitives.UWP/SideDrawer/RadSideDrawer.cs
+++ b/Controls/Primitives/Primitives.UWP/SideDrawer/RadSideDrawer.cs
@@ -428,6 +428,11 @@ namespace Telerik.UI.Xaml.Controls.Primitives
                 return;
             }
 
+            if (!this.Context.IsContextValid(this.DrawerLocation, this.DrawerTransition))
+            {
+                this.UpdateLayout();
+            }
+
             if (this.DrawerState == DrawerState.Closed)
             {
                 this.Context.MainContentStoryBoard.Begin();
@@ -674,7 +679,7 @@ namespace Telerik.UI.Xaml.Controls.Primitives
         private static void OnDrawerTransitionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sideDrawer = d as RadSideDrawer;
-            if (sideDrawer.drawer != null)
+            if (sideDrawer.drawer != null && (DrawerTransition)e.NewValue != (DrawerTransition)e.OldValue)
             {
                 sideDrawer.ResetDrawer();
             }
@@ -720,7 +725,7 @@ namespace Telerik.UI.Xaml.Controls.Primitives
         private static void OnDrawerLocationChagned(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var sideDrawer = d as RadSideDrawer;
-            if (sideDrawer.drawer != null)
+            if (sideDrawer.drawer != null && (DrawerLocation)e.NewValue != (DrawerLocation)e.OldValue)
             {
                 sideDrawer.ResetDrawer();
             }


### PR DESCRIPTION
Fix a bug that drawer is shown at the wrong location when the DrawerLocation is changed but ShowDrawer is called before layout is updated. For example when on button clicked the DrawerLocation is changed and right after that ShowDrawer is called. When this happens the change of the DrawerLocation calls InvalidateMeasure but before the layout pass the ShowDrawer method is called, which plays a the animation associated with the previous DrawerLocation value.