### PR TITLE
Fix an issue that packaging with latest nuget.exe results in error NU…

### DIFF
--- a/BuildTools/Nuspecs.UWP/Package.UniversalWindowsPlatform.nuspec
+++ b/BuildTools/Nuspecs.UWP/Package.UniversalWindowsPlatform.nuspec
@@ -16,11 +16,7 @@
         <language>en-US</language>
     </metadata>
     <files>
-        <file src="$DeployDirectory$\$BinariesSubDir$\**" target="lib\uap10.0" exclude="$DeployDirectory$\$BinariesSubDir$\ARM\**;$DeployDirectory$\$BinariesSubDir$\ARM64\**;DeployDirectory$\$BinariesSubDir$\x86\**;$DeployDirectory$\$BinariesSubDir$\x64\**"/>
-        <file src="$DeployDirectory$\$BinariesSubDir$\ARM\**\*" target="lib\uap10.0\ARM"/>
-        <file src="$DeployDirectory$\$BinariesSubDir$\ARM64\**\*" target="lib\uap10.0\ARM64"/>
-        <file src="$DeployDirectory$\$BinariesSubDir$\x86\**\*" target="lib\uap10.0\x86"/>
-        <file src="$DeployDirectory$\$BinariesSubDir$\x64\**\*" target="lib\uap10.0\x64"/>
+        <file src="$DeployDirectory$\$BinariesSubDir$\**" target="lib\uap10.0"/>
         <file src="$NuspecsDir$\$Id$.targets" target="build\uap10.0"/>
 		<file src="$NuspecsDir$\VisualStudioToolsManifest.xml" target="tools"/>
         <file src="$DeployDirectory$\License.md" target="LicenseAgreements" />


### PR DESCRIPTION
…5050: Attempted to pack multiple files into the same location(s). The issue is with nuget.exe version 5.10 and above.

Change nuspec to copy the contents of Binaries folder to lib folder when packing nuget, without excluding ARM, ARM64, x86 and x64 folders and then copying them one by one.
With this change packing with latest nuget.exe does not result in error.