### PR TITLE
Fix RadDataGrid frozen column edit bug

### DIFF
--- a/Controls/Grid/Grid.UWP/View/ContainerGenerators/XamlGridEditCellGenerator.cs
+++ b/Controls/Grid/Grid.UWP/View/ContainerGenerators/XamlGridEditCellGenerator.cs
@@ -79,7 +79,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
                     {
                         if (info.IsFrozen)
                         {
-                            this.owner.FrozenEditRowLayer.AddVisualChild(pair.Item2);
+                            this.owner.FrozenEditRowLayer.AddVisualChild(element);
                         }
                         else
                         {


### PR DESCRIPTION
Fix for #508 RadDataGrid NRE when inline editing a row with a frozen read-only column
