### PR TITLE
Fix copy/paste bug in EditingService.cs

### DIFF
--- a/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -85,7 +85,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
                         this.Owner.EditRowLayer.ScheduleFirstEditorForFocus();
                     }
 
-                    this.Owner.Model.CurrentDataProvider.CommitEditOperation(this.EditItem);
+                    this.Owner.Model.CurrentDataProvider.BeginEditOperation(this.EditItem);
 
                     // hide the CurrentItem decoration
                     this.Owner.visualStateService.UpdateCurrentDecoration(-1); 
@@ -189,7 +189,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
                     this.Owner.EditRowLayer.EditorLayoutSlots.Clear();
                 }
 
-                this.Owner.Model.CurrentDataProvider.CommitEditOperation(this.EditItem);
+                this.Owner.Model.CurrentDataProvider.CancelEditOperation(this.EditItem);
             })
             {
                 Flags = UpdateFlags.AffectsContent

--- a/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
@@ -204,7 +204,6 @@ namespace Telerik.UI.Xaml.Controls.Grid
 
             this.Owner.updateService.RegisterUpdate(update);
 
-
             if (this.operation.EditMode == DataGridUserEditMode.Inline)
             {
                 this.Owner.EditRowLayer.EditorLayoutSlots.Clear();

--- a/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -181,26 +181,29 @@ namespace Telerik.UI.Xaml.Controls.Grid
                     if (trigger != ActionTrigger.ExternalEditor)
                     {
                         this.Owner.ExternalEditor.CancelEdit();
+                        this.Owner.CurrencyService.RefreshCurrentItem(true);
                     }
                 }
                 else
                 {
                     this.Owner.Model.CancelEdit();
                     this.Owner.EditRowLayer.EditorLayoutSlots.Clear();
+                    this.Owner.CurrencyService.RefreshCurrentItem(true);
                 }
 
                 this.Owner.Model.CurrentDataProvider.CancelEditOperation(this.EditItem);
             })
             {
-                Flags = UpdateFlags.AffectsContent
+                Flags = UpdateFlags.AffectsData
             };
-
-            this.Owner.updateService.RegisterUpdate(update);
 
             foreach (var pair in this.operation.OriginalValues)
             {
                 pair.Key.SetValueForInstance(this.operation.EditItemInfo.Item, pair.Value);
             }
+
+            this.Owner.updateService.RegisterUpdate(update);
+
 
             if (this.operation.EditMode == DataGridUserEditMode.Inline)
             {

--- a/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
@@ -118,18 +118,20 @@ namespace Telerik.UI.Xaml.Controls.Grid
                         if (trigger != ActionTrigger.ExternalEditor)
                         {
                             this.Owner.ExternalEditor.CommitEdit();
+                            this.Owner.CurrencyService.RefreshCurrentItem(true);
                         }
                     }
                     else
                     {
                         this.Owner.Model.CommitEdit();
                         this.Owner.EditRowLayer.EditorLayoutSlots.Clear();
+                        this.Owner.CurrencyService.RefreshCurrentItem(true);
                     }
 
                     this.Owner.Model.CurrentDataProvider.CommitEditOperation(this.EditItem);
                 })
                 {
-                    Flags = UpdateFlags.AffectsContent,
+                    Flags = UpdateFlags.AffectsData,
                     Priority = CoreDispatcherPriority.Low
                 };
 
@@ -138,7 +140,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
 
             this.Owner.updateService.RegisterUpdate(update);
 
-                update = new DelegateUpdate<UpdateFlags>(() =>
+            update = new DelegateUpdate<UpdateFlags>(() =>
                 {
                     if (this.Owner.UserEditMode == DataGridUserEditMode.External)
                     {

--- a/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -181,20 +181,18 @@ namespace Telerik.UI.Xaml.Controls.Grid
                     if (trigger != ActionTrigger.ExternalEditor)
                     {
                         this.Owner.ExternalEditor.CancelEdit();
-                        this.Owner.CurrencyService.RefreshCurrentItem(true);
                     }
                 }
                 else
                 {
                     this.Owner.Model.CancelEdit();
                     this.Owner.EditRowLayer.EditorLayoutSlots.Clear();
-                    this.Owner.CurrencyService.RefreshCurrentItem(true);
                 }
 
                 this.Owner.Model.CurrentDataProvider.CancelEditOperation(this.EditItem);
             })
             {
-                Flags = UpdateFlags.AffectsData
+                Flags = UpdateFlags.AffectsContent
             };
 
             foreach (var pair in this.operation.OriginalValues)

--- a/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
@@ -204,6 +204,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
 
             this.Owner.updateService.RegisterUpdate(update);
 
+
             if (this.operation.EditMode == DataGridUserEditMode.Inline)
             {
                 this.Owner.EditRowLayer.EditorLayoutSlots.Clear();

--- a/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
+++ b/Controls/Grid/Grid.UWP/View/Services/Editing/EditingService.cs
@@ -118,20 +118,18 @@ namespace Telerik.UI.Xaml.Controls.Grid
                         if (trigger != ActionTrigger.ExternalEditor)
                         {
                             this.Owner.ExternalEditor.CommitEdit();
-                            this.Owner.CurrencyService.RefreshCurrentItem(true);
                         }
                     }
                     else
                     {
                         this.Owner.Model.CommitEdit();
                         this.Owner.EditRowLayer.EditorLayoutSlots.Clear();
-                        this.Owner.CurrencyService.RefreshCurrentItem(true);
                     }
 
                     this.Owner.Model.CurrentDataProvider.CommitEditOperation(this.EditItem);
                 })
                 {
-                    Flags = UpdateFlags.AffectsData,
+                    Flags = UpdateFlags.AffectsContent,
                     Priority = CoreDispatcherPriority.Low
                 };
 
@@ -140,7 +138,7 @@ namespace Telerik.UI.Xaml.Controls.Grid
 
             this.Owner.updateService.RegisterUpdate(update);
 
-            update = new DelegateUpdate<UpdateFlags>(() =>
+                update = new DelegateUpdate<UpdateFlags>(() =>
                 {
                     if (this.Owner.UserEditMode == DataGridUserEditMode.External)
                     {


### PR DESCRIPTION
Fix a copy/paste bug in EditingService.cs that caused the data grid view state to go haywire when using inline editing mode on rows with MVVM properties (i.e. properties that send PropertyChanged notifications).

Also, ensure the row is refreshed/redrawn when inline edits are cancelled. Previously, canceled edits would still appear on the row until the view was refreshed/redrawn by other means such as resizing the column.